### PR TITLE
Add support for Emonpi URL

### DIFF
--- a/Firmware/IotaWatt/Changelog.ino
+++ b/Firmware/IotaWatt/Changelog.ino
@@ -29,5 +29,6 @@
  *   07/23/17 2.02.07 Overhaul RTC initialization and power fail logging
  *   07/23/17 2.02.08 Add LED problem indicators during startup
  *   07/23/17 2.02.09 Add LED indication of connection and timer status
+ *   08/07/17 2.02.10 Add Emonpi URL support
  *   
  *****************************************************************************************************/

--- a/Firmware/IotaWatt/IotaWatt.ino
+++ b/Firmware/IotaWatt/IotaWatt.ino
@@ -23,7 +23,7 @@
       SOFTWARE.
       ***********************************************************************************/
 
-#define IOTAWATT_VERSION "2.02.09"
+#define IOTAWATT_VERSION "2.02.10"
 
 #define PRINT(txt,val) Serial.print(txt); Serial.print(val);      // Quick debug aids
 #define PRINTL(txt,val) Serial.print(txt); Serial.println(val);
@@ -206,6 +206,7 @@ uint8_t ledCount;                             // Current index into cycle
 bool eMonStarted = false;                    // set true when Service started
 bool eMonStop = false;                       // set true to stop the Service                                         
 String  eMonURL;                             // These are set from the config file 
+String  eMonPiUri = "";
 String apiKey;
 String node = "IotaWatt";
 boolean eMonSecure = false;

--- a/Firmware/IotaWatt/eMonService.ino
+++ b/Firmware/IotaWatt/eMonService.ino
@@ -1,4 +1,4 @@
-   /*******************************************************************************************************
+    /*******************************************************************************************************
  * eMonService - This SERVICE posts entries from the IotaLog to eMonCMS.  Details of the eMonCMS
  * account are provided in the configuration file at startup and this SERVICE is scheduled.  It runs
  * more or less independent of everything else, just reading the log records as they become available
@@ -148,7 +148,7 @@ uint32_t eMonService(struct serviceBlock* _serviceBlock){
           // If new request, format preamble, otherwise, just tack it on with a comma.
       
       if(req.length() == 0){
-        req = "/input/bulk.json?time=" + String(UnixNextPost) + "&apikey=" + apiKey + "&data=[";
+        req = eMonPiUri + "/input/bulk.json?time=" + String(UnixNextPost) + "&apikey=" + apiKey + "&data=[";
         currentReqUnixtime = UnixNextPost;
       }
       else {

--- a/Firmware/IotaWatt/getConfig.ino
+++ b/Firmware/IotaWatt/getConfig.ino
@@ -140,7 +140,12 @@ boolean getConfig(void)
     if(eMonURL.startsWith("http://")) eMonURL = eMonURL.substring(7);
     else if(eMonURL.startsWith("https://")){
       eMonURL = eMonURL.substring(8);
-      eMonSecure = true;
+    }
+    eMonPiUri = "";
+    if(eMonURL.indexOf("/") > 0){
+      eMonPiUri = eMonURL.substring(eMonURL.indexOf("/"));
+      eMonURL.remove(eMonURL.indexOf("/"));
+      msg += "(Emonpi)";
     }
     msg += ", url: " + eMonURL;
     apiKey = Config["server"]["apikey"].asString();


### PR DESCRIPTION
Emonpi requires the URI start with /emoncms.  Change to add anything
after the domain (or IP) address to beginning of URI.