### PR TITLE
restore missing config file

### DIFF
--- a/SD/config.txt
+++ b/SD/config.txt
@@ -1,0 +1,55 @@
+{
+	"format": 2,
+	"timezone": 0,
+	"device": {
+		"name": "IotaWatt",
+		"version": 3,
+		"channels": "15",
+		"burden": [
+			0,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24,
+			24
+		]
+	},
+	"inputs": [
+		{
+			"channel": 0,
+			"name": "Voltage",
+			"type": "VT",
+			"model": "generic240V",
+			"phase": 2,
+			"cal": 23
+		},
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null
+	],
+	"outputs": [],
+	"server": {
+		"type": "none"
+	},
+	"update": "MAJOR"
+}


### PR DESCRIPTION
wops, when I renamed the config file to remove the space I forgot the `git add` the non-space config file back into the repo. Here it is! Sorry about that. 