### PR TITLE
Added .vscode folder to gitignore

### DIFF
--- a/Firmware/.gitignore
+++ b/Firmware/.gitignore
@@ -6,3 +6,4 @@
 .piolibdeps
 .clang_complete
 .gcc-flags.json
+.vscode


### PR DESCRIPTION
When I've tried to build and test firmware in platformio-vscode-ide this ignore was added automatically. I thought it would be useful to have it in upstream.