### PR TITLE
Get phase from tables at startup

### DIFF
--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -291,5 +291,6 @@ boolean   getConfig(void);
 void      sendChunk(char* bufr, uint32_t bufrPos);
 String    base64encode(const uint8_t* in, size_t len);
 
+String    hashName(const char* name);
 String    formatHex(uint32_t);
 #endif

--- a/Firmware/IotaWatt/graphSave.cpp
+++ b/Firmware/IotaWatt/graphSave.cpp
@@ -1,7 +1,7 @@
 #include "IotaWatt.h"
 
 #define graphDir "graphs"
-String hashFileName(const char* name);
+String hashName(const char* name);
 
 void handleGraphCreate(){
   File graphFile = SD.open(graphDir);
@@ -20,7 +20,7 @@ void handleGraphCreate(){
   DynamicJsonBuffer Json;
   JsonObject& graph = Json.parseObject(server.arg("data"));
   String filePath = graphDir;
-  String fileName = hashFileName(graph["name"].as<char*>());
+  String fileName = hashName(graph["name"].as<char*>());
   filePath += "/" + fileName + ".txt";
   SD.remove(filePath);
   graphFile = SD.open(filePath, FILE_WRITE);
@@ -75,7 +75,7 @@ void handleGraphGetall(){
   return;
 }
 
-String hashFileName(const char* name){
+String hashName(const char* name){
   uint8_t hash[6];
   sha256.reset();
   sha256.update(name, strlen(name));


### PR DESCRIPTION
Get phase corection from tables if model is in the tables file.  This
paves the way for correction as a function of current (or voltage) and
makes improved phase correction work without editing config file.