### PR TITLE
Low blocking NTP time update

### DIFF
--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -83,6 +83,7 @@ extern String historyLogFile;
 extern String IotaMsgLog;
 extern String EmonPostLogFile;
 extern String influxPostLogFile;
+extern const char* ntpServerName;
 extern uint16_t deviceVersion;
 
         // Define the hardware pins

--- a/Firmware/IotaWatt/IotaWatt.ino
+++ b/Firmware/IotaWatt/IotaWatt.ino
@@ -90,6 +90,7 @@ String historyLogFile = "/IotaWatt/histLog";
 String IotaMsgLog = "/IotaWatt/IotaMsgs.txt";
 String EmonPostLogFile = "/iotawatt/Emonlog.log";
 String influxPostLogFile = "/iotawatt/influxdb.log";
+const char* ntpServerName = "pool.ntp.org";
 
                        
 uint8_t ADC_selectPin[2] = {pin_CS_ADC0,    // indexable reference for ADC select pins


### PR DESCRIPTION
Restructure NTP time request to be mostly asynchronous.  Blocks only to
resolve domain to IP.
Change to use pool.ntp.org for better global response.