### PR TITLE
use units in script evaluation

### DIFF
--- a/Firmware/IotaWatt/GetFeedData.cpp
+++ b/Firmware/IotaWatt/GetFeedData.cpp
@@ -145,9 +145,6 @@ uint32_t getFeedData(struct serviceBlock* _serviceBlock){
       bufr[4] = '\n'; 
       bufrPos = 5;
       server.setContentLength(CONTENT_LENGTH_UNKNOWN);
-      // chunked content implicit with CONTENT_LENGTH_UNKNOWN in new core webServer. (02_02_22)  
-      // server.sendHeader("Accept-Ranges","none");
-      // server.sendHeader("Transfer-Encoding","chunked");
       server.send(200,"application/json","");
       replyData = "[";
       UnixTime = startUnixTime;
@@ -203,16 +200,16 @@ uint32_t getFeedData(struct serviceBlock* _serviceBlock){
               replyData += "null";
             }
             else if(reqPtr->queryType == 'V'){
-              replyData += String(reqPtr->output->run([](int i)->double {
-                return (logRecord->accum1[i] - lastRecord->accum1[i]) / elapsedHours;}), 1);
+              replyData += String(reqPtr->output->run(lastRecord, logRecord, elapsedHours), 1);
             }
             else if(reqPtr->queryType == 'P'){
-              replyData += String(reqPtr->output->run([](int i)->double {
-                return (logRecord->accum1[i] - lastRecord->accum1[i]) / elapsedHours;}), 1);
+              replyData += String(reqPtr->output->run(lastRecord, logRecord, elapsedHours), 1);
             }
             else if(reqPtr->queryType == 'E'){
-                replyData += String(reqPtr->output->run([](int i)->double {
-                              return logRecord->accum1[i] / 1000.0;}), 2);
+                replyData += String(reqPtr->output->run(lastRecord, logRecord, 1000.0), 2);
+            }
+            else if(reqPtr->queryType == 'O'){
+              replyData += String(reqPtr->output->run(lastRecord, logRecord, elapsedHours), 3);
             }
             else {
               replyData += "null";

--- a/Firmware/IotaWatt/IotaScript.cpp
+++ b/Firmware/IotaWatt/IotaScript.cpp
@@ -1,4 +1,37 @@
+#include "IotaWatt.h"
 #include "IotaScript.h"
+
+Script::Script(JsonObject& JsonScript) {
+      _next = NULL;
+      JsonVariant var = JsonScript["name"];
+      if(var.success()){
+        _name = charstar(var.as<char*>());
+      }
+      _units = charstar("Watts");
+      _accum = 0;
+      var = JsonScript["units"];
+      if(var.success()){
+             if(strcmp_ci(var.as<char*>(), "Watts") == 0){_units = charstar("Watts");}
+        else if(strcmp_ci(var.as<char*>(), "Volts") == 0){_units = charstar("Volts");}
+        else if(strcmp_ci(var.as<char*>(), "Amps" ) == 0){_units = charstar("Amps"); _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "Hz"   ) == 0){_units = charstar("Hz"); _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "pf"   ) == 0){_units = charstar("pf"); _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "VA"   ) == 0){_units = charstar("VA"); _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "Wh"   ) == 0){_units = charstar("Wh"); _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "kWh"  ) == 0){_units = charstar("kWh"); _accum = 1;}  
+      }
+      var = JsonScript["script"];
+      if(var.success()){
+        encodeScript(var.as<char*>() );
+      }
+    }
+
+Script::~Script() {
+      delete[] _name;
+      delete[] _units;
+      delete[] _tokens;
+      delete[] _constants;
+    }
 
 Script*   Script::next() {return _next;}
 
@@ -73,13 +106,21 @@ bool    Script::encodeScript(const char* script){
         _tokens[tokenCount] = 0;
 }
 
-double  Script::run(double inputCallback(int)){
+double  Script::run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours){
         uint8_t* tokens = _tokens;
-        return runRecursive(&tokens, inputCallback);
+        double result = runRecursive(&tokens, oldRec, newRec, elapsedHours);
+        if(strcmp(_units, "pf") == 0){
+          _accum = 0;
+          result = runRecursive(&tokens, oldRec, newRec, elapsedHours) / result;
+          if(result > 1.1) result = 0.0;
+          _accum = 1;
+        }
+        if(result != result) return 0.0;
+        return result;
                 
 }
 
-double  Script::runRecursive(uint8_t** tokens, double inputCallback(int)){
+double  Script::runRecursive(uint8_t** tokens, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours){
         double result = 0.0;
         double operand = 0.0;
         uint8_t pendingOp = opAdd;
@@ -96,7 +137,7 @@ double  Script::runRecursive(uint8_t** tokens, double inputCallback(int)){
           }       
           else if(*token == opPush){
             token++;
-            operand = runRecursive(&token, inputCallback);
+            operand = runRecursive(&token, oldRec, newRec, elapsedHours);
           }
           else if(*token == opPop){ 
             *tokens = token;
@@ -107,7 +148,17 @@ double  Script::runRecursive(uint8_t** tokens, double inputCallback(int)){
           }
         
           if(*token & getInputOp){
-            operand = inputCallback(*token % 32);
+            if(_accum == 0){
+              operand = (newRec->accum1[*token % 32] - (oldRec ? oldRec->accum1[*token % 32] : 0.0)) / elapsedHours;
+            }
+            else {
+              operand = (newRec->accum2[*token % 32] - (oldRec ? oldRec->accum2[*token % 32] : 0.0)) / elapsedHours;
+            }
+            if(operand != operand) operand = 0;
+            if(strcmp(_units, "Amps") == 0){
+              int vchannel = inputChannel[*token % 32]->_vchannel;
+              operand /= (newRec->accum1[vchannel] - (oldRec ? oldRec->accum1[vchannel] : 0.0)) / elapsedHours;
+            }
           }
           if(*token & getConstOp){
             operand = _constants[*token % 32];
@@ -124,6 +175,9 @@ double    Script::evaluate(double result, uint8_t token, double operand){
           case opMult:
             return result * operand;
           case opDiv:
-            return result / operand;    
+            if(operand == 0){
+              return 0;
+            }
+            return result / operand;        
         }
 }

--- a/Firmware/IotaWatt/IotaScript.h
+++ b/Firmware/IotaWatt/IotaScript.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include "iotalog.h"
 
 class Script {
 
@@ -10,36 +11,14 @@ class Script {
 
   public:
 
-    Script(JsonObject& JsonScript) {
-      _next = NULL;
-      JsonVariant var = JsonScript["name"];
-      if(var.success()){
-        _name = new char[strlen(var.as<char*>())+1];
-        strcpy(_name, var.as<char*>());
-      }
-      var = JsonScript["units"];
-      if(var.success()){
-        _units = new char[strlen(var.as<char*>())+1];
-        strcpy(_units, var.as<char*>());
-      }
-      var = JsonScript["script"];
-      if(var.success()){
-        encodeScript(var.as<char*>() );
-      }
-    }
-
-    ~Script() {
-      delete[] _name;
-      delete[] _units;
-      delete[] _tokens;
-      delete[] _constants;
-    }
+    Script(JsonObject&); 
+    ~Script();
 
     char*   name();     // name associated with this Script
     char*   units();    // units associated with this Script
     Script*   next();     // -> next Script in set
 
-    double    run(double inputCallback(int)); // Run this Script
+    double    run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours); // Run this Script
     void    print();
 
   private:
@@ -48,6 +27,7 @@ class Script {
     char*       _name;      // name associated with this Script
     char*       _units;     // units associated with this Script
     uint8_t*    _tokens;    // Script tokens
+    uint8_t     _accum;     // Accumulators to use in fetching operands
     float*     _constants;   // Constant values referenced in Script
     const byte  getInputOp = 32;
     const byte  getConstOp = 64;
@@ -62,7 +42,7 @@ class Script {
                 opPop   = 7};
     const char* opChars = "=+-*/|()";
 
-    double    runRecursive(uint8_t**, double inputCallback(int));
+    double    runRecursive(uint8_t**, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours);
     double    evaluate(double, byte, double);
     bool      encodeScript(const char* script);
 

--- a/Firmware/IotaWatt/IotaWatt.ino
+++ b/Firmware/IotaWatt/IotaWatt.ino
@@ -135,7 +135,7 @@ float   frequency = 55;                  // Split the difference to start
 float   samplesPerCycle = 550;           // Here as well
 float   cycleSampleRate = 0;
 int16_t cycleSamples = 0;
-dataBuckets statBucket[MAXINPUTS];
+IotaLogRecord statRecord;                 // Maintained by statService with real-time values
 
       // ****************************** SDWebServer stuff ****************************
 

--- a/Firmware/IotaWatt/Setup.cpp
+++ b/Firmware/IotaWatt/Setup.cpp
@@ -186,18 +186,6 @@ void setup()
 }  // setup()
 /***************************************** End of Setup **********************************************/
 
-
-String formatHex(uint32_t data){
-  const char* hexDigits = "0123456789ABCDEF";
-  String str = "00000000";
-  uint32_t _data = data;
-  for(int i=7; i>=0; i--){
-    str[i] = hexDigits[_data % 16];
-    _data /= 16;
-  }
-  return str;
-}
-
 void dropDead(void){dropDead("R.R.R...");}
 void dropDead(const char* pattern){
   msgLog(F("Program halted."));

--- a/Firmware/IotaWatt/getConfig.cpp
+++ b/Firmware/IotaWatt/getConfig.cpp
@@ -342,20 +342,3 @@ void phaseTableAdd(phaseTableEntry** phaseTable, JsonArray& table){
     }
   }
 }
-
-char* charstar(const char* str){
-  char* ptr = new char[strlen(str)+1];
-  strcpy(ptr, str);
-  return ptr;
-}
-
-char* charstar(String str){
-  return charstar(str.c_str());
-}
-
-char* charstar(const char str){
-  char* ptr = new char[2];
-  ptr[0] = str;
-  ptr[1] = 0;
-  return ptr;
-}

--- a/Firmware/IotaWatt/graphSave.cpp
+++ b/Firmware/IotaWatt/graphSave.cpp
@@ -74,12 +74,3 @@ void handleGraphGetall(){
   directory.close();
   return;
 }
-
-String hashName(const char* name){
-  SHA256 sha256;
-  uint8_t hash[6];
-  sha256.reset();
-  sha256.update(name, strlen(name));
-  sha256.finalize(hash, 6);
-  return base64encode(hash, 6);
-}

--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -237,7 +237,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       char separator = ' ';
       trace(T_influx,8);
       while(script){
-        double value = script->run([](int i)->double {return (logRecord->accum1[i] - oldRecord->accum1[i]) / elapsedHours;});
+        double value = script->run(oldRecord, logRecord, elapsedHours);
         if(value == value){
           reqData.printf_P(PSTR("%c%s=%.1f"), separator, script->name(), value);
           separator = ',';

--- a/Firmware/IotaWatt/statService.cpp
+++ b/Firmware/IotaWatt/statService.cpp
@@ -1,0 +1,54 @@
+#include "IotaWatt.h"
+
+/******************************************************************************************************** 
+ * All of the other SERVICEs that harvest values from the main "buckets" do so for their own selfish 
+ * purposes, and have no global scope to share with others. This simple service maintains periodic
+ * values for each of the buckets in a global set of buckets called statBucket.  It also is where 
+ * status statistics like sample rates are maintained.  
+ *******************************************************************************************************/
+
+uint32_t statService(struct serviceBlock* _serviceBlock) { 
+  static boolean started = false;
+  static uint32_t timeThen = millis();        
+  static float  damping = .25;
+  static double accum1Then[MAXINPUTS];
+  static double accum2Then[MAXINPUTS];
+  uint32_t timeNow = millis();
+
+  if(!started){
+    msgLog(F("statService: started."));
+    started = true;
+    for(int i=0; i<maxInputs; i++){
+      accum1Then[i] = inputChannel[i]->dataBucket.accum1;
+      accum2Then[i] = inputChannel[i]->dataBucket.accum2;
+      statRecord.accum1[i] = 0.0;
+      statRecord.accum2[i] = 0.0;
+    }
+    return (uint32_t)UNIXtime() + 1;
+  }
+  
+  double elapsedHrs = double((uint32_t)(timeNow - timeThen)) / MS_PER_HOUR;
+
+  for(int i=0; i<maxInputs; i++){
+    inputChannel[i]->ageBuckets(timeNow);
+    double newValue = (inputChannel[i]->dataBucket.accum1 - accum1Then[i]) / elapsedHrs;
+    if(abs(statRecord.accum1[i] - newValue) / abs(statRecord.accum1[i]) < 0.02){
+      statRecord.accum1[i] = damping * statRecord.accum1[i] + (1.0 - damping) * newValue;
+    }
+    else statRecord.accum1[i] = newValue;
+    newValue = (inputChannel[i]->dataBucket.accum2 - accum2Then[i]) / elapsedHrs;
+    if(abs(statRecord.accum2[i] - newValue) / abs(statRecord.accum2[i]) < 0.02){
+      statRecord.accum2[i] = damping * statRecord.accum2[i] + (1.0 - damping) * newValue;
+    }
+    else statRecord.accum2[i] = newValue;
+    accum1Then[i] = inputChannel[i]->dataBucket.accum1;
+    accum2Then[i] = inputChannel[i]->dataBucket.accum2;
+  }
+  
+  cycleSampleRate = damping * cycleSampleRate + (1.0 - damping) * float(cycleSamples * 1000) / float((uint32_t)(timeNow - timeThen));
+  cycleSamples = 0;
+  timeThen = timeNow;
+  
+  return ((uint32_t)UNIXtime() + statServiceInterval);
+}
+

--- a/Firmware/IotaWatt/utilities.cpp
+++ b/Firmware/IotaWatt/utilities.cpp
@@ -1,0 +1,117 @@
+#include "IotaWatt.h"
+
+/**************************************************************************************************
+ * Case insensitive string compare.  Works just like strcmp() just case insensitive 
+ * ************************************************************************************************/
+int strcmp_ci(const char* str1, const char* str2){
+    const char* char1 = str1;
+    const char* char2 = str2;
+    while(*char1 || *char2){
+        if(*(char1++) != *(char2++)){
+            if(toupper(*(char1-1)) > toupper(*(char2-1))) return +1;
+            if(toupper(*(char1-1)) < toupper(*(char2-1))) return -1;
+        }
+    }
+    return 0;
+}
+
+/**************************************************************************************************
+ * allocate a char* array, copy the argument data to it, and return the pointer. 
+ * ************************************************************************************************/
+char* charstar(const char* str){
+  char* ptr = new char[strlen(str)+1];
+  strcpy(ptr, str);
+  return ptr;
+}
+
+char* charstar(String str){
+  return charstar(str.c_str());
+}
+
+char* charstar(const char str){
+  char* ptr = new char[2];
+  ptr[0] = str;
+  ptr[1] = 0;
+  return ptr;
+}
+
+/**************************************************************************************************
+ * Hash the input string to an eight character base64 String 
+ * ************************************************************************************************/
+String hashName(const char* name){
+  SHA256 sha256;
+  uint8_t hash[6];
+  sha256.reset();
+  sha256.update(name, strlen(name));
+  sha256.finalize(hash, 6);
+  return base64encode(hash, 6);
+}
+
+/**************************************************************************************************
+ * Convert the input to a String of hex digits.
+ * ************************************************************************************************/
+String formatHex(uint32_t data){
+  const char* hexDigits = "0123456789ABCDEF";
+  String str = "00000000";
+  uint32_t _data = data;
+  for(int i=7; i>=0; i--){
+    str[i] = hexDigits[_data % 16];
+    _data /= 16;
+  }
+  return str;
+}
+
+String bin2hex(const uint8_t* in, size_t len){
+  static const char* hexcodes = "0123456789abcdef";
+  String out = "";
+  for(int i=0; i<len; i++){
+    out += hexcodes[*in >> 4];
+    out += hexcodes[*in++ & 0x0f];
+  }
+  return out;
+}
+
+/**************************************************************************************************
+ * Convert the contents of an xbuf to base64
+ * ************************************************************************************************/
+void base64encode(xbuf* buf){
+  const char* base64codes = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  size_t supply = buf->available();
+  uint8_t in[3];
+  uint8_t out[4];
+  trace(T_base64,0);
+  while(supply >= 3){
+    buf->read(in,3);
+    out[0] = (uint8_t) base64codes[in[0]>>2];
+    out[1] = (uint8_t) base64codes[(in[0]<<4 | in[1]>>4) & 0x3f];
+    out[2] = (uint8_t) base64codes[(in[1]<<2 | in[2]>>6) & 0x3f];
+    out[3] = (uint8_t) base64codes[in[2] & 0x3f];
+    buf->write(out, 4);
+    supply -= 3;
+  }
+  trace(T_base64,0);
+  if(supply > 0){
+    in[0] = in[1] = in[2] = 0;
+    buf->read(in,supply);
+    out[0] = (uint8_t) base64codes[in[0]>>2];
+    out[1] = (uint8_t) base64codes[(in[0]<<4 | in[1]>>4) & 0x3f];
+    out[2] = (uint8_t) base64codes[(in[1]<<2 | in[2]>>6) & 0x3f];
+    out[3] = (uint8_t) base64codes[in[2] & 0x3f];
+    if(supply == 1) {
+      out[2] = out[3] = (uint8_t) '=';
+    }
+    else if(supply == 2){
+      out[3] = (uint8_t) '=';
+    }
+    buf->write(out, 4);
+  }
+}
+
+String base64encode(const uint8_t* in, size_t len){
+  trace(T_base64,1);
+  xbuf work;
+  work.write(in, len);
+  base64encode(&work);
+  return work.readString(work.available());
+}
+

--- a/Firmware/IotaWatt/utilities.h
+++ b/Firmware/IotaWatt/utilities.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/*********************************************************************************************************
+ * 
+ *      Various utilities that are generally useful but not necessarily part of anything in particular.
+ * 
+ * *******************************************************************************************************/
+
+int strcmp_ci(const char*, const char*);            // Case insensitive strcmp()
+
+char* charstar(const char* str);                    // Create a new char* array...
+char* charstar(String str);                         // copy the argument to it...
+char* charstar(const char str);                     // return a pointer.
+
+String hashName(const char* name);                  // hash the input string to an eight character base 64 string
+String formatHex(uint32_t data);                    // Convert the input to a String of hex digits
+String bin2hex(const uint8_t* in, size_t len);
+
+void base64encode(xbuf* buf);                       // Convert the contents of an xbuf to base64
+String base64encode(const uint8_t* in, size_t len); // Convert the input buffer to a base64 String

--- a/SD/index.htm
+++ b/SD/index.htm
@@ -279,7 +279,8 @@
           <h3  style="text-align:center">Configure Output</h3>
           <table><tr><th width="30%"></th><th></th></tr>
             <tr><td class="calcField"><strong>Name:</strong></td><td><input id="calcName" pattern="[a-zA-Z]{1}[a-zA-Z0-9_]*" oninput="refreshCalcDisplay()" title="invalid name"></td></tr>
-            <tr><td class="calcField"><strong>Units:</strong></td><td><input id="calcUnits" oninput="refreshCalcDisplay()"></td></tr>
+            <tr><td class="calcField"><strong>Units:</strong></td><td><select id="calcUnits" oninput="refreshCalcDisplay()"></td>
+            </tr>
           </table>
         </form>
         <h3 id="calcDisplay">0</h3>  
@@ -361,6 +362,9 @@ var scriptEditSet;
 var scriptEditIndex = -1;
 var scriptEditSave;
 var scriptEditReturn;
+var scriptEditUnits = [];
+var scriptEditUnitsOutput = ["Watts","Volts","Amps","Hz","pf","VA"];
+var scriptEditUnitsUpload = ["Watts","Volts","Amps","Hz","pf","VA","Wh","kWh"];
 
 /***************************************************************************************************
  *                       Shorthand functions
@@ -911,7 +915,7 @@ function calVTsave(obj){
     scriptEditTable = EbyId("outputTable");
     scriptEditTable.innerHTML = "";
     scriptEditSet = config.outputs;
-    
+    scriptEditUnits = scriptEditUnitsOutput;
     editScript();
   }
   
@@ -985,7 +989,7 @@ function calVTsave(obj){
     editingScript = true;
     currentBodyPush("divCalc");
     EbyId("calcName").value = scriptEditSet[index].name;
-    EbyId("calcUnits").value = scriptEditSet[index].units;
+    buildUnitsList(scriptEditSet[index].units);
     tokens = parseScript(scriptEditSet[index].script);
     EbyId("calcDelete").style.display = "inline";
     scriptEditIndex = index;
@@ -996,7 +1000,7 @@ function calVTsave(obj){
     editingScript = true;
     currentBodyPush("divCalc");
     EbyId("calcName").value = "";
-    EbyId("calcUnits").value = "";
+    buildUnitsList("watts");
     tokens = ["#0"];
     EbyId("calcDelete").style.display = "none";
     scriptEditIndex = scriptEditSet.length;
@@ -1039,8 +1043,8 @@ function calVTsave(obj){
     EbyId("calcDisplay").innerHTML = scriptDisplay(tokens);
     var calcName = EbyId("calcName");
     if(EbyId("calcName").value.trim() == "" ||
-       parenLevel > 0 || 
-       RegExp("^[-+*\/]").test(tokens[tokens.length-1])){
+      parenLevel > 0 || 
+      RegExp("^[-+*\/]").test(tokens[tokens.length-1])){
       EbyId("calcSave").style.display = "none";
     }
     else if (! RegExp(calcName.pattern).test(calcName.value)){
@@ -1048,7 +1052,23 @@ function calVTsave(obj){
     }
     else EbyId("calcSave").style.display = "inline";
   }
-
+  
+  function buildUnitsList(units){
+    var calcUnits = EbyId("calcUnits");
+    while(calcUnits.hasChildNodes()){
+      calcUnits.removeChild(calcUnits.firstChild);
+    }
+    for(i in scriptEditUnits){
+      var option = document.createElement("option");
+      option.value = scriptEditUnits[i];
+      option.innerHTML = scriptEditUnits[i];
+      calcUnits.appendChild(option);
+      if(option.value == units){
+        option.selected = true;
+      }
+    }
+  }
+  
   function parseScript(script){
     return script.match(/@\d+|#-?\d+\.?\d*|[-+*\/()|=]/g);
   }
@@ -1487,6 +1507,7 @@ function editEmoncms(){
   };
   scriptEditTable = EbyId("serverOutputs");
   scriptEditSet = config.server.outputs;
+  scriptEditUnits = scriptEditUnitsUpload;
   editScript();
   checkEmoncms();
 }
@@ -1617,6 +1638,7 @@ function editInfluxdb(){
   };
   scriptEditTable = EbyId("serverOutputs");
   scriptEditSet = config.influxdb.outputs;
+  scriptEditUnits = scriptEditUnitsUpload;
   editScript();
   checkInfluxdb();
 }
@@ -1796,7 +1818,7 @@ function statusDisplay(statusMessage){
     
     if(status.inputs[i].Watts !== undefined){
       var wattNode = document.createElement("font");
-      wattNode.innerHTML = status.inputs[i].Watts + "&nbsp;" + "watts";
+      wattNode.innerHTML = status.inputs[i].Watts + "&nbsp;" + "Watts";
       column3.appendChild(wattNode);
       
       if(status.inputs[i].reversed == "true"){
@@ -1814,7 +1836,7 @@ function statusDisplay(statusMessage){
       
     }
     else if(status.inputs[i].Vrms !== undefined){
-      column3.appendChild(document.createTextNode(status.inputs[i].Vrms.toFixed(1) + " volts"));
+      column3.appendChild(document.createTextNode(status.inputs[i].Vrms.toFixed(1) + " Volts"));
     }
   }
   
@@ -1824,7 +1846,7 @@ function statusDisplay(statusMessage){
     addRow();
     column1.innerHTML += "<strong>" + config.outputs[i].name + ":</strong>";
     var wattNode = document.createElement("font");
-    wattNode.innerHTML = status.outputs[i].value.toFixed(0) + " " + status.outputs[i].units;
+    wattNode.innerHTML = status.outputs[i].value.toFixed(unitsPrecision(status.outputs[i].units)) + " " + status.outputs[i].units;
     column3.appendChild(wattNode);
   }
     
@@ -1841,6 +1863,16 @@ function statusDisplay(statusMessage){
     column3 = document.createElement("td");
     newRow.appendChild(column3);
   }
+}
+
+function unitsPrecision(units){
+  if(units == "Watts") return 1;
+  if(units == "Volts") return 1;
+  if(units == "Amps") return 2;
+  if(units == "Hz") return 1;
+  if(units == "pf") return 2;
+  if(units == "VA") return 1;
+  return 1;
 }
 
 function formatRunTime(time){


### PR DESCRIPTION
Evaluate scripts for the units specified.
With VA now available, it's possible to produce amps, pf as well, so
this change does that.
the run script method in iotaScript changes.  Rather than a callback to
get referenced data, caller provides the current logrec and the previous
logrec.  For real-time evaluation, only a current rec is provided with
the current values.