### PR TITLE
Add precision to script attributes.

### DIFF
--- a/Firmware/IotaWatt/GetFeedData.cpp
+++ b/Firmware/IotaWatt/GetFeedData.cpp
@@ -209,7 +209,7 @@ uint32_t getFeedData(struct serviceBlock* _serviceBlock){
                 replyData += String(reqPtr->output->run(lastRecord, logRecord, 1000.0), 2);
             }
             else if(reqPtr->queryType == 'O'){
-              replyData += String(reqPtr->output->run(lastRecord, logRecord, elapsedHours), 3);
+              replyData += String(reqPtr->output->run(lastRecord, logRecord, elapsedHours), reqPtr->output->precision());
             }
             else {
               replyData += "null";

--- a/Firmware/IotaWatt/IotaLog.cpp
+++ b/Firmware/IotaWatt/IotaLog.cpp
@@ -109,16 +109,13 @@ int IotaLog::readKey (IotaLogRecord* callerRecord){
 		callerRecord->UNIXtime = key;
 		return 1;
 	}
-	if(key > _lastKey){														// Back to the future
+	if(key >= _lastKey){														// Back to the future
 		readSerial(callerRecord, _lastSerial);
 		callerRecord->UNIXtime = key;
+		if(key = _lastKey) return 0;
 		return 1;
 	}
-	/* 
-	Serial.print("search: ");
-	Serial.print(key);
-	Serial.println();
-	*/
+	//Serial.printf("search %d, highKey %d\r\n", key, _firstKey);
 	uint32_t lowKey = _firstKey;
 	int32_t lowSerial = _firstSerial;
 	uint32_t highKey = _lastKey;
@@ -156,21 +153,7 @@ void IotaLog::searchKey(IotaLogRecord* callerRecord, const uint32_t key, const u
   int32_t floorSerial = max(lowSerial, highSerial - (int32_t)((highKey - key) / _interval));
 	int32_t ceilingSerial = min(highSerial, lowSerial + (int32_t)((key - lowKey) / _interval));
 
-	/* 
-	Serial.print("low: ");
-	Serial.print(lowKey);
-	Serial.print("(");
-	Serial.print(lowSerial);
-	Serial.print("), high: ");
-	Serial.print(highKey);
-	Serial.print("(");
-	Serial.print(highSerial);
-	Serial.print("), floor: ");
-	Serial.print(floorSerial);
-	Serial.print(", ceiling: ");
-	Serial.print(ceilingSerial);
-	Serial.println();
-	*/ 
+	//Serial.printf("low %d(%d), high %d(%d), floor %d, Ceiling %d\r\n", lowKey, lowSerial, highKey, highSerial,floorSerial, ceilingSerial); 
 
   if(ceilingSerial < highSerial || floorSerial == ceilingSerial){
 		readSerial(callerRecord, ceilingSerial);
@@ -189,7 +172,7 @@ void IotaLog::searchKey(IotaLogRecord* callerRecord, const uint32_t key, const u
 		searchKey(callerRecord, key, callerRecord->UNIXtime, callerRecord->serial, highKey, highSerial);
 		return;
   }
-  if((highSerial - lowSerial) <= 1){
+  if((highSerial - lowSerial) <= 1){		
 		readSerial(callerRecord, lowSerial);
 		return;
   }

--- a/Firmware/IotaWatt/IotaScript.cpp
+++ b/Firmware/IotaWatt/IotaScript.cpp
@@ -11,14 +11,14 @@ Script::Script(JsonObject& JsonScript) {
       _accum = 0;
       var = JsonScript["units"];
       if(var.success()){
-             if(strcmp_ci(var.as<char*>(), "Watts") == 0){_units = charstar("Watts");}
-        else if(strcmp_ci(var.as<char*>(), "Volts") == 0){_units = charstar("Volts");}
-        else if(strcmp_ci(var.as<char*>(), "Amps" ) == 0){_units = charstar("Amps"); _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "Hz"   ) == 0){_units = charstar("Hz"); _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "pf"   ) == 0){_units = charstar("pf"); _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "VA"   ) == 0){_units = charstar("VA"); _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "Wh"   ) == 0){_units = charstar("Wh"); _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "kWh"  ) == 0){_units = charstar("kWh"); _accum = 1;}  
+             if(strcmp_ci(var.as<char*>(), "Watts") == 0){_units = charstar("Watts"); _dec = 2;}
+        else if(strcmp_ci(var.as<char*>(), "Volts") == 0){_units = charstar("Volts"); _dec = 2;}
+        else if(strcmp_ci(var.as<char*>(), "Amps" ) == 0){_units = charstar("Amps"); _dec=3; _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "Hz"   ) == 0){_units = charstar("Hz"); _dec=2; _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "pf"   ) == 0){_units = charstar("pf"); _dec=3; _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "VA"   ) == 0){_units = charstar("VA"); _dec=2; _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "Wh"   ) == 0){_units = charstar("Wh"); _dec=4; _accum = 1;}
+        else if(strcmp_ci(var.as<char*>(), "kWh"  ) == 0){_units = charstar("kWh"); _dec=7; _accum = 1;}  
       }
       var = JsonScript["script"];
       if(var.success()){
@@ -108,6 +108,12 @@ bool    Script::encodeScript(const char* script){
 
 double  Script::run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours){
         uint8_t* tokens = _tokens;
+        if(strcmp(_units, "Wh") == 0){
+          elapsedHours = 1.0;
+        }
+        else if(strcmp(_units, "kWh") == 0){
+          elapsedHours = 1000.0;
+        }
         double result = runRecursive(&tokens, oldRec, newRec, elapsedHours);
         if(strcmp(_units, "pf") == 0){
           _accum = 0;

--- a/Firmware/IotaWatt/IotaScript.h
+++ b/Firmware/IotaWatt/IotaScript.h
@@ -20,15 +20,17 @@ class Script {
 
     double    run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours); // Run this Script
     void    print();
+    int     precision(){return _dec;}
 
   private:
 
     Script*     _next;      // -> next in list
     char*       _name;      // name associated with this Script
     char*       _units;     // units associated with this Script
+    float*     _constants;  // Constant values referenced in Script
     uint8_t*    _tokens;    // Script tokens
     uint8_t     _accum;     // Accumulators to use in fetching operands
-    float*     _constants;   // Constant values referenced in Script
+    uint8_t     _dec;       // Decimal places to report
     const byte  getInputOp = 32;
     const byte  getConstOp = 64;
     enum        opCodes {

--- a/Firmware/IotaWatt/eMonService.cpp
+++ b/Firmware/IotaWatt/eMonService.cpp
@@ -276,12 +276,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
         while(script){
           while(index++ < String(script->name()).toInt()) reqData.write(",null");
           value1 = script->run(lastRecord, logRecord, elapsedHours);
-          if(value1 > -1.0 && value1 < 1){
-            reqData.write(",0");
-          }
-          else {
-            reqData.printf(",%.1f", value1);
-          }
+          reqData.printf(",%.*f", script->precision(), value1);
           script = script->next();
         }
       }

--- a/Firmware/IotaWatt/historyLog.cpp
+++ b/Firmware/IotaWatt/historyLog.cpp
@@ -40,7 +40,7 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
          return UNIXtime() + histLog.interval(); 
       }
 
-      msgLog(F("historyLog: service started.")); 
+      msgLog(F("historyLog: service started."));
 
         // Initialize the historyLog class
      
@@ -69,6 +69,16 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
         histLog.write(logRecord);
         delete logRecord;
       }
+
+      logRecord = new IotaLogRecord;
+      for(uint32_t key = histLog.lastKey() - histLog.interval() * 20; key <= histLog.lastKey(); key += histLog.interval()){
+        logRecord->UNIXtime = key;
+        histLog.readKey(logRecord);
+        Serial.printf("key %d, time %.6f, power1 %.6f\r\n", key, logRecord->logHours, logRecord->accum1[1]);
+      }
+      delete logRecord;
+
+
       trace(T_history,3); 
       _serviceBlock->priority = priorityLow;
       state = logData;

--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -239,7 +239,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       while(script){
         double value = script->run(oldRecord, logRecord, elapsedHours);
         if(value == value){
-          reqData.printf_P(PSTR("%c%s=%.1f"), separator, script->name(), value);
+          reqData.printf_P(PSTR("%c%s=%.*f"), separator, script->name(), script->precision(), value);
           separator = ',';
         }
         script = script->next();
@@ -269,7 +269,6 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
 
     case sendPost: {
       trace(T_influx,9);
-     
       if( ! WiFi.isConnected()){
         return UNIXtime() + 1;
       }
@@ -329,7 +328,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       reqData.flush();
       reqEntries = 0;    
       state = post;
-      return UnixNextPost;
+      return UnixNextPost+1;
     }   
   }
 


### PR DESCRIPTION
Set precision of script output based on units and add precision() method to retrieve it.
Fix problem with last logrec returning next to last when read by key.