### PR TITLE
Formalize units and produce script output in designated units

### DIFF
--- a/Firmware/IotaWatt/IotaScript.cpp
+++ b/Firmware/IotaWatt/IotaScript.cpp
@@ -1,34 +1,62 @@
 #include "IotaWatt.h"
 #include "IotaScript.h"
 
-Script::Script(JsonObject& JsonScript) {
+const char*      unitstr[] = {
+                    "Watts",
+                    "Volts", 
+                    "Amps", 
+                    "VA", 
+                    "Hz", 
+                    "Wh", 
+                    "kWh", 
+                    "PF",
+                    ""
+                    };
+
+uint8_t     unitsPrecision[] = { 
+                    /*Watts*/ 2,
+                    /*Volts*/ 2, 
+                    /*Amps*/  3, 
+                    /*VA*/    2, 
+                    /*Hz*/    2, 
+                    /*Wh*/    4, 
+                    /*kWh*/   7, 
+                    /*PF*/    3,
+                    /*None*/  0 
+                    };                   
+
+Script::Script(JsonObject& JsonScript)
+      :_next(nullptr)
+      ,_name(nullptr)
+      ,_constants(nullptr)
+      ,_tokens(nullptr)
+      ,_units(unitsWatts)
+      
+     {
       _next = NULL;
       JsonVariant var = JsonScript["name"];
       if(var.success()){
         _name = charstar(var.as<char*>());
       }
-      _units = charstar("Watts");
-      _accum = 0;
+    
+      _units = unitsWatts;
       var = JsonScript["units"];
       if(var.success()){
-             if(strcmp_ci(var.as<char*>(), "Watts") == 0){_units = charstar("Watts"); _dec = 2;}
-        else if(strcmp_ci(var.as<char*>(), "Volts") == 0){_units = charstar("Volts"); _dec = 2;}
-        else if(strcmp_ci(var.as<char*>(), "Amps" ) == 0){_units = charstar("Amps"); _dec=3; _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "Hz"   ) == 0){_units = charstar("Hz"); _dec=2; _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "pf"   ) == 0){_units = charstar("pf"); _dec=3; _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "VA"   ) == 0){_units = charstar("VA"); _dec=2; _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "Wh"   ) == 0){_units = charstar("Wh"); _dec=4; _accum = 1;}
-        else if(strcmp_ci(var.as<char*>(), "kWh"  ) == 0){_units = charstar("kWh"); _dec=7; _accum = 1;}  
+        for(int i=0; i<unitsNone; i++){
+          if(strcmp_ci(var.as<char*>(),unitstr[i]) == 0){
+            _units = (units)i;
+            break;
+          } 
+        }
       }
       var = JsonScript["script"];
       if(var.success()){
-        encodeScript(var.as<char*>() );
+        encodeScript(var.as<char*>());
       }
     }
 
 Script::~Script() {
       delete[] _name;
-      delete[] _units;
       delete[] _tokens;
       delete[] _constants;
     }
@@ -37,7 +65,9 @@ Script*   Script::next() {return _next;}
 
 char*     Script::name() {return _name;} 
 
-char*   Script::units(){return _units;}
+const char* Script::getUnits() {return unitstr[_units];};
+
+int     Script::precision(){return unitsPrecision[_units];};
 
 size_t    ScriptSet::count() {return _count;}
 
@@ -108,25 +138,49 @@ bool    Script::encodeScript(const char* script){
 
 double  Script::run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours){
         uint8_t* tokens = _tokens;
-        if(strcmp(_units, "Wh") == 0){
-          elapsedHours = 1.0;
+        double result, var, watts;
+        switch(_units) {
+
+          case unitsWatts:
+          case unitsVolts:
+            result = runRecursive(&tokens, oldRec, newRec, elapsedHours, '1'); 
+            break;
+
+          case unitsWh:
+            result = runRecursive(&tokens, oldRec, newRec, 1.0, '1'); 
+            break;
+
+          case unitskWh:
+            result = runRecursive(&tokens, oldRec, newRec, 1000.0, '1'); 
+            break;
+            
+          case unitsAmps:
+            result = runRecursive(&tokens, oldRec, newRec, elapsedHours, 'A'); 
+            break;
+
+          case unitsVA:
+            var = runRecursive(&tokens, oldRec, newRec, elapsedHours, 'R');
+            watts = runRecursive(&tokens, oldRec, newRec, elapsedHours, '1');
+            result = sqrt(watts*watts + var*var); 
+            break;
+
+          case unitsHz:
+            result = runRecursive(&tokens, oldRec, newRec, elapsedHours, '2'); 
+            break;
+
+          case unitsPF:
+            watts = runRecursive(&tokens, oldRec, newRec, elapsedHours, '1');
+            var = runRecursive(&tokens, oldRec, newRec, elapsedHours, 'R');
+            result = watts / sqrt(watts*watts + var*var); 
+            break;
         }
-        else if(strcmp(_units, "kWh") == 0){
-          elapsedHours = 1000.0;
-        }
-        double result = runRecursive(&tokens, oldRec, newRec, elapsedHours);
-        if(strcmp(_units, "pf") == 0){
-          _accum = 0;
-          result = runRecursive(&tokens, oldRec, newRec, elapsedHours) / result;
-          if(result > 1.1) result = 0.0;
-          _accum = 1;
-        }
+        
         if(result != result) return 0.0;
         return result;
                 
 }
 
-double  Script::runRecursive(uint8_t** tokens, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours){
+double  Script::runRecursive(uint8_t** tokens, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours, char type){
         double result = 0.0;
         double operand = 0.0;
         uint8_t pendingOp = opAdd;
@@ -143,7 +197,7 @@ double  Script::runRecursive(uint8_t** tokens, IotaLogRecord* oldRec, IotaLogRec
           }       
           else if(*token == opPush){
             token++;
-            operand = runRecursive(&token, oldRec, newRec, elapsedHours);
+            operand = runRecursive(&token, oldRec, newRec, elapsedHours, type);
           }
           else if(*token == opPop){ 
             *tokens = token;
@@ -152,23 +206,39 @@ double  Script::runRecursive(uint8_t** tokens, IotaLogRecord* oldRec, IotaLogRec
           else if(*token == opEq){
             return evaluate(result, pendingOp, operand);
           }
-        
-          if(*token & getInputOp){
-            if(_accum == 0){
-              operand = (newRec->accum1[*token % 32] - (oldRec ? oldRec->accum1[*token % 32] : 0.0)) / elapsedHours;
-            }
-            else {
-              operand = (newRec->accum2[*token % 32] - (oldRec ? oldRec->accum2[*token % 32] : 0.0)) / elapsedHours;
-            }
-            if(operand != operand) operand = 0;
-            if(strcmp(_units, "Amps") == 0){
-              int vchannel = inputChannel[*token % 32]->_vchannel;
-              operand /= (newRec->accum1[vchannel] - (oldRec ? oldRec->accum1[vchannel] : 0.0)) / elapsedHours;
-            }
-          }
           if(*token & getConstOp){
             operand = _constants[*token % 32];
           }
+
+              // Fetch input operand.
+              // accum1 is Wh, Vh
+              // accum2 is VAh, Hzh
+              // Type 1 retieves accum1
+              // Type 2 retrieves accum2
+              // Type R computes var as sqrt(VA^2 - W^2)
+              // Type A computes Amps as VA / V
+
+          if(*token & getInputOp){
+            if(type == '1'){
+              operand = (newRec->accum1[*token % 32] - (oldRec ? oldRec->accum1[*token % 32] : 0.0)) / elapsedHours;
+            }
+            else if(type == '2'){
+              operand = (newRec->accum2[*token % 32] - (oldRec ? oldRec->accum2[*token % 32] : 0.0)) / elapsedHours;
+            }
+            else if(type == 'R'){
+              double VA = (newRec->accum2[*token % 32] - (oldRec ? oldRec->accum2[*token % 32] : 0.0)) / elapsedHours;
+              double W = (newRec->accum1[*token % 32] - (oldRec ? oldRec->accum1[*token % 32] : 0.0)) / elapsedHours;
+              operand = sqrt(VA*VA - W*W);
+            }
+            else if(type == 'A'){
+              double VA = (newRec->accum2[*token % 32] - (oldRec ? oldRec->accum2[*token % 32] : 0.0)) / elapsedHours;
+              int vchannel = inputChannel[*token % 32]->_vchannel;
+              operand = VA / (newRec->accum1[vchannel] - (oldRec ? oldRec->accum1[vchannel] : 0.0)) / elapsedHours;
+            }
+            else operand = 0.0;
+            if(operand != operand) operand = 0;
+          }
+
         } while(token++);
 }
 

--- a/Firmware/IotaWatt/IotaScript.h
+++ b/Firmware/IotaWatt/IotaScript.h
@@ -15,22 +15,32 @@ class Script {
     ~Script();
 
     char*   name();     // name associated with this Script
-    char*   units();    // units associated with this Script
-    Script*   next();     // -> next Script in set
+    const char*   getUnits();    // units associated with this Script
+    void    setUnits(const char*);
+    Script* next();     // -> next Script in set
 
-    double    run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours); // Run this Script
+    double  run(IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours); // Run this Script
     void    print();
-    int     precision(){return _dec;}
+    int     precision();
 
   private:
 
     Script*     _next;      // -> next in list
     char*       _name;      // name associated with this Script
-    char*       _units;     // units associated with this Script
-    float*     _constants;  // Constant values referenced in Script
+    float*      _constants; // Constant values referenced in Script
     uint8_t*    _tokens;    // Script tokens
-    uint8_t     _accum;     // Accumulators to use in fetching operands
-    uint8_t     _dec;       // Decimal places to report
+    enum        units {
+                    unitsWatts = 0,
+                    unitsVolts = 1,
+                    unitsAmps = 2,
+                    unitsVA = 3,
+                    unitsHz = 4,
+                    unitsWh = 5,
+                    unitskWh = 6,
+                    unitsPF = 7,
+                    unitsNone = 8
+                    } _units;         // Units to be computed              
+    uint8_t     _accum;               // Accumulators to use in fetching operands
     const byte  getInputOp = 32;
     const byte  getConstOp = 64;
     enum        opCodes {
@@ -44,7 +54,7 @@ class Script {
                 opPop   = 7};
     const char* opChars = "=+-*/|()";
 
-    double    runRecursive(uint8_t**, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours);
+    double    runRecursive(uint8_t**, IotaLogRecord* oldRec, IotaLogRecord* newRec, double elapsedHours, char type);
     double    evaluate(double, byte, double);
     bool      encodeScript(const char* script);
 

--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -32,9 +32,9 @@
 #include <ESP8266mDNS.h>
 #include <DNSServer.h>
 #include <WiFiClient.h>
-#include <ESP8266HTTPClient.h>
+//#include <ESP8266HTTPClient.h>
 #include <ESP8266WebServer.h>
-#include <ESP8266httpUpdate.h>
+//#include <ESP8266httpUpdate.h>
 #include <ESPAsyncTCP.h>
 #include <asyncHTTPrequest.h>
 

--- a/Firmware/IotaWatt/eMonService.cpp
+++ b/Firmware/IotaWatt/eMonService.cpp
@@ -344,14 +344,17 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
         if(++retryCount  % 10 == 0){
             msgLog("EmonService: retry count ", retryCount);
         }
-        state = sendPost;
+        UnixLastPost = reqUnixtime - EmonCMSInterval;
+        state = primeLastRecord;
         return UNIXtime() + 1;
       }
       trace(T_Emon,8);
       String response = request->responseText();
       if(! response.startsWith("ok")){
         msgLog("EmonService: response not ok. Retrying.");
-        state = sendPost;
+        Serial.println(response.substring(0,60));
+        UnixLastPost = reqUnixtime - EmonCMSInterval;
+        state = primeLastRecord;
         return UNIXtime() + 1;
       }
       trace(T_Emon,8);

--- a/Firmware/IotaWatt/historyLog.cpp
+++ b/Firmware/IotaWatt/historyLog.cpp
@@ -70,15 +70,6 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
         delete logRecord;
       }
 
-      logRecord = new IotaLogRecord;
-      for(uint32_t key = histLog.lastKey() - histLog.interval() * 20; key <= histLog.lastKey(); key += histLog.interval()){
-        logRecord->UNIXtime = key;
-        histLog.readKey(logRecord);
-        Serial.printf("key %d, time %.6f, power1 %.6f\r\n", key, logRecord->logHours, logRecord->accum1[1]);
-      }
-      delete logRecord;
-
-
       trace(T_history,3); 
       _serviceBlock->priority = priorityLow;
       state = logData;

--- a/Firmware/IotaWatt/utilities.cpp
+++ b/Firmware/IotaWatt/utilities.cpp
@@ -109,7 +109,8 @@ void base64encode(xbuf* buf){
 
 String base64encode(const uint8_t* in, size_t len){
   trace(T_base64,1);
-  xbuf work;
+  size_t _len = len * 2 + len;
+  xbuf work(_len < 64 ? _len : 64);
   work.write(in, len);
   base64encode(&work);
   return work.readString(work.available());

--- a/Firmware/IotaWatt/webServer.cpp
+++ b/Firmware/IotaWatt/webServer.cpp
@@ -327,7 +327,7 @@ void handleStatus(){
     while(script){
       JsonObject& channelObject = jsonBuffer.createObject();
       channelObject.set("name",script->name());
-      channelObject.set("units",script->units());
+      channelObject.set("units",script->getUnits());
       double value = script->run((IotaLogRecord*)nullptr, &statRecord, 1.0);
       channelObject.set("value",value);
       outputArray.add(channelObject);
@@ -477,7 +477,7 @@ void handleGetFeedList(){
   int outndx = 100;
   while(script){
     if(String(script->name()).indexOf(' ') == -1){
-      String units = String(script->units());
+      String units = String(script->getUnits());
       if(units.equalsIgnoreCase("volts")){
         JsonObject& voltage = jsonBuffer.createObject();
         voltage["id"] = String("OV") + String(script->name());

--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =  ArduinoJson@5.13.1
             RTClib@1.2.1 
             Crypto@0.1.3
             ESPAsyncTCP@1.1.3 
-            asyncHTTPrequest@1.1.3
+            asyncHTTPrequest@1.1.4
 
 # default environment, compile and upload using; `$ pio run -t upload`
 [env:iotawatt]

--- a/SD/index.htm
+++ b/SD/index.htm
@@ -363,8 +363,8 @@ var scriptEditIndex = -1;
 var scriptEditSave;
 var scriptEditReturn;
 var scriptEditUnits = [];
-var scriptEditUnitsOutput = ["Watts","Volts","Amps","Hz","pf","VA"];
-var scriptEditUnitsUpload = ["Watts","Volts","Amps","Hz","pf","VA","Wh","kWh"];
+var scriptEditUnitsOutput = ["Watts","Volts","Amps","Hz","PF","VA"];
+var scriptEditUnitsUpload = ["Watts","Volts","Amps","Hz","PF","VA","Wh","kWh"];
 
 /***************************************************************************************************
  *                       Shorthand functions
@@ -1844,7 +1844,7 @@ function statusDisplay(statusMessage){
   statusTable.innerHTML = "";
   for(i in status.outputs){
     addRow();
-    column1.innerHTML += "<strong>" + config.outputs[i].name + ":</strong>";
+    column1.innerHTML += "<strong>" + status.outputs[i].name + ":</strong>";
     var wattNode = document.createElement("font");
     wattNode.innerHTML = status.outputs[i].value.toFixed(unitsPrecision(status.outputs[i].units)) + " " + status.outputs[i].units;
     column3.appendChild(wattNode);
@@ -1870,7 +1870,7 @@ function unitsPrecision(units){
   if(units == "Volts") return 1;
   if(units == "Amps") return 2;
   if(units == "Hz") return 1;
-  if(units == "pf") return 2;
+  if(units == "PF") return 2;
   if(units == "VA") return 1;
   return 1;
 }


### PR DESCRIPTION
Units were previously just an arbitrary tag assigned by the user.
This change recognizes 8 basic units Watts, Volts, Amps, VA, PF, Hz, Wh,
kWh.  Anything else in old config defaults to Watts.
Script->run produces values in the specified units using the appropriate
data from a datalog record.