### PR TITLE
Divide and conquer Config Json

### DIFF
--- a/Firmware/IotaWatt/Emonservice.h
+++ b/Firmware/IotaWatt/Emonservice.h
@@ -7,7 +7,7 @@ String bin2hex(const uint8_t* in, size_t len);
 String base64encode(const uint8_t* in, size_t len);
 void   base64encode(xbuf*);
 uint32_t EmonService(struct serviceBlock* _serviceBlock);
-bool EmonConfig(JsonObject& config);
+bool EmonConfig(const char*);
 
 extern bool     EmonStarted;                      // set true when Service started
 extern bool     EmonStop;                         // set true to stop the Service

--- a/Firmware/IotaWatt/eMonService.cpp
+++ b/Firmware/IotaWatt/eMonService.cpp
@@ -291,7 +291,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
       
       if ((reqEntries < EmonBulkSend) ||
          ((currLog.lastKey() > UnixNextPost) &&
-         (reqData.available() < 2000))) {
+         (reqData.available() < 1000))) {
         return UnixNextPost;
       }
 
@@ -494,7 +494,13 @@ case sendSecure:{
           // EmonConfig - process the configuration Json
           // invoked from getConfig
 
-bool EmonConfig(JsonObject& config){
+bool EmonConfig(const char* configObj){
+  DynamicJsonBuffer Json;
+  JsonObject& config = Json.parseObject(configObj);
+  if( ! config.success()){
+    msgLog(F("EmonService: Json parse failed."));
+    return false;
+  }
   trace(T_EmonConfig,0);
   if(config["type"].as<String>() != "emoncms"){
     EmonStop = true;

--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -335,7 +335,13 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
   return 1;
 }
 
-bool influxConfig(JsonObject& config){
+bool influxConfig(const char* configObj){
+  DynamicJsonBuffer Json;
+  JsonObject& config = Json.parseObject(configObj);
+  if( ! config.success()){
+    msgLog(F("influxService: Json parse failed."));
+    return false;
+  }
   int revision = config["revision"];
   if(revision == influxRevision){
     return true;
@@ -390,5 +396,6 @@ bool influxConfig(JsonObject& config){
     influxStarted = true;
     influxStop = false;
   }
+  return true;
 }
 

--- a/Firmware/IotaWatt/influxDB.h
+++ b/Firmware/IotaWatt/influxDB.h
@@ -20,7 +20,7 @@ struct influxTag {
 };
 
 uint32_t influxService(struct serviceBlock* _serviceBlock);
-bool influxConfig(JsonObject& config);
+bool influxConfig(const char*);
 
 extern bool     influxStarted;                    // set true when Service started
 extern bool     influxStop;                       // set true to stop the Service

--- a/Firmware/IotaWatt/utilities.h
+++ b/Firmware/IotaWatt/utilities.h
@@ -18,3 +18,6 @@ String bin2hex(const uint8_t* in, size_t len);
 
 void base64encode(xbuf* buf);                       // Convert the contents of an xbuf to base64
 String base64encode(const uint8_t* in, size_t len); // Convert the input buffer to a base64 String
+
+String  JsonSummary(File file, int depth);          // Read a json file and return a summary Json string              
+char*  JsonDetail(File file, JsonArray& locator);   // Read and compress a detail segment of a json file


### PR DESCRIPTION
Parse config to one level and index the deeper level in the file.  When
needed, retrieve the deeper levels and parse separately, then discard.
Reduces dynamic heap requirement significantly.