### PR TITLE
Fixed case of include to work in Linux

### DIFF
--- a/Firmware/IotaWatt/IotaScript.h
+++ b/Firmware/IotaWatt/IotaScript.h
@@ -3,7 +3,7 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
-#include "iotalog.h"
+#include "IotaLog.h"
 
 enum        units {
             unitsWatts = 0,


### PR DESCRIPTION
Linux requires includes to be case correct.  This seems to fix builds in VSCode on recent Ubuntu.