### PR TITLE
No semaphore on web server, WiFi WDT

### DIFF
--- a/Firmware/IotaWatt/Loop.cpp
+++ b/Firmware/IotaWatt/Loop.cpp
@@ -32,7 +32,7 @@ void loop()
   yield();
   ESP.wdtFeed();
   trace(T_LOOP,3);
-  if(serverAvailable && HTTPrequestFree){
+  if(serverAvailable){
     server.handleClient();
     trace(T_LOOP,4);
     yield();

--- a/Firmware/IotaWatt/WiFi.cpp
+++ b/Firmware/IotaWatt/WiFi.cpp
@@ -1,9 +1,9 @@
 #include "IotaWatt.h"
 
 uint32_t WiFiService(struct serviceBlock* _serviceBlock) {
-  const byte DNS_PORT = 53;
-  IPAddress apIP(192, 168, 4, 1);
-  
+  static uint32_t lastDisconnect = millis();          // Time of last disconnect
+  const uint32_t disconnectRestart = 2;               // Restart ESP if disconnected this many hours  
+
   if(WiFi.status() == WL_CONNECTED){
     if(!wifiConnected){
       wifiConnected = true;
@@ -14,13 +14,14 @@ uint32_t WiFiService(struct serviceBlock* _serviceBlock) {
   else {
     if(wifiConnected){
       wifiConnected = false;
+      lastDisconnect = millis();
       log("WiFi disconnected.");
+    }
+    else if((millis() - lastDisconnect) >= (3600000UL * disconnectRestart)){
+      log("WiFi disconnected more than %d hours, restarting.", disconnectRestart);
+      delay(500);
+      ESP.restart();
     }
   }
   return UNIXtime() + 1;  
 }
-
-void handleDisconnect(){
-  returnOK();
-  WiFi.disconnect();
-} 


### PR DESCRIPTION
Remove semaphore check on webserver handleClient().
Set wdt for WiFi disconnect (2 hours).