### PR TITLE
Web server authorization preliminary changes

### DIFF
--- a/Firmware/IotaWatt/Setup.cpp
+++ b/Firmware/IotaWatt/Setup.cpp
@@ -153,24 +153,9 @@ void setup()
    
  //*************************************** Start the web server ****************************
 
-  server.on(F("/status"),HTTP_GET, handleStatus);
-  server.on(F("/vcal"),HTTP_GET, handleVcal);
-  server.on(F("/command"), HTTP_GET, handleCommand);
-  server.on(F("/list"), HTTP_GET, printDirectory);
-  server.on(F("/config"), HTTP_GET, handleGetConfig);
-  server.on(F("/edit"), HTTP_DELETE, handleDelete);
-  server.on(F("/edit"), HTTP_PUT, handleCreate);
-  server.on(F("/edit"), HTTP_POST, returnOK, handleFileUpload);
-  server.on(F("/feed/list.json"), handleGetFeedList);
-  server.on(F("/feed/data.json"), handleGetFeedData);
-  server.on(F("/graph/create"),HTTP_POST, handleGraphCreate);
-  server.on(F("/graph/update"),HTTP_POST, handleGraphCreate);
-  server.on(F("/graph/delete"),HTTP_POST, handleGraphDelete);
-  server.on(F("/graph/getall"), handleGraphGetall);
-  server.onNotFound(handleNotFound);
-
   SdFile::dateTimeCallback(dateTime);
-
+  server.on(F("/edit"), HTTP_POST, returnOK,  handleFileUpload);
+  server.onNotFound(handleRequest);
   server.begin();
   log("HTTP server started");
   WiFi.mode(WIFI_STA);

--- a/Firmware/IotaWatt/webServer.h
+++ b/Firmware/IotaWatt/webServer.h
@@ -1,6 +1,10 @@
 #ifndef webServer_h
 #define webServer_h
 
+ typedef std::function<void(void)> genericHandler;
+
+void handleRequest();
+bool serverOn(const __FlashStringHelper* uri, HTTPMethod method, genericHandler fn);
 void returnOK();
 void returnFail(String msg);
 bool loadFromSdCard(String path);


### PR DESCRIPTION
Modify web-server to be gatekeeper instead of specifying server.on
handlers. Bonus was a good size chunk of heap saved w/o all those
handler data structures.  New logic uses progmem more.