### PR TITLE
No wifimanager unless power cycle

### DIFF
--- a/Firmware/IotaWatt/IotaLog.cpp
+++ b/Firmware/IotaWatt/IotaLog.cpp
@@ -291,7 +291,7 @@ void IotaLog::dumpFile(){
 	SD.remove(diagPath);
 	File logDiag = SD.open(diagPath, FILE_WRITE);
 	if(logDiag){
-		DateTime now = DateTime(localUNIXtime());
+		DateTime now = DateTime(localTime());
     logDiag.printf_P(PSTR("%d/%02d/%02d %02d:%02d:%02d\r\nfilesize %d, entries %d\r\n"),
     now.month(), now.day(), now.year()%100, now.hour(), now.minute(), now.second(),
 		IotaFile.size(), _entries);

--- a/Firmware/IotaWatt/IotaScript.cpp
+++ b/Firmware/IotaWatt/IotaScript.cpp
@@ -61,17 +61,17 @@ Script::~Script() {
       delete[] _constants;
     }
 
-Script*   Script::next() {return _next;}
+Script*       Script::next() {return _next;}
 
-char*     Script::name() {return _name;} 
+const char*   Script::name() {return _name;} 
 
-const char* Script::getUnits() {return unitstr[_units];};
+const char*   Script::getUnits() {return unitstr[_units];};
 
-int     Script::precision(){return unitsPrecision[_units];};
+int           Script::precision(){return unitsPrecision[_units];};
 
-size_t    ScriptSet::count() {return _count;}
+size_t        ScriptSet::count() {return _count;}
 
-Script*   ScriptSet::first() {return _listHead;}  
+Script*       ScriptSet::first() {return _listHead;}  
 
 void    Script::print() {
         uint8_t* token = _tokens;

--- a/Firmware/IotaWatt/IotaScript.h
+++ b/Firmware/IotaWatt/IotaScript.h
@@ -26,7 +26,7 @@ class Script {
     Script(JsonObject&); 
     ~Script();
 
-    char*   name();     // name associated with this Script
+    const char*   name();     // name associated with this Script
     const char*   getUnits();    // units associated with this Script
     void    setUnits(const char*);
     Script* next();     // -> next Script in set

--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -64,6 +64,7 @@
 #include "auth.h"
 #include "spiffs.h"
 #include "timeServices.h"
+#include "pvoutput.h"
 
 
       // Declare instances of major classes
@@ -147,7 +148,8 @@ extern traceUnion traceEntry;
 #define T_stats 18         // Stat service 
 #define T_datalog 19       // datalog service
 #define T_timeSync 20      // timeSync service 
-#define T_WiFi 21          // WiFi service  
+#define T_WiFi 21          // WiFi service
+#define T_PVoutput 22      // PVoutput class     
 
       // LED codes
 

--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -251,6 +251,7 @@ extern uint32_t updaterServiceInterval;        // Interval (sec) to check for so
 
 extern bool     hasRTC;
 extern bool     RTCrunning;
+extern bool     powerFailRestart;               // Set true on power fail restart (detected by RTC)  
 
 extern char     ledColor[12];                   // Pattern to display led, each char is 500ms color - R, G, Blank
 extern uint8_t  ledCount;                       // Current index into cycle

--- a/Firmware/IotaWatt/IotaWatt.ino
+++ b/Firmware/IotaWatt/IotaWatt.ino
@@ -191,6 +191,7 @@ uint32_t updaterServiceInterval = 60*60;     // Interval (sec) to check for soft
 
 bool     hasRTC = false;
 bool     RTCrunning = false;
+bool     powerFailRestart = false;   
 
 char     ledColor[12];                       // Pattern to display led, each char is 500ms color - R, G, Blank
 uint8_t  ledCount;                           // Current index into cycle

--- a/Firmware/IotaWatt/Loop.cpp
+++ b/Firmware/IotaWatt/Loop.cpp
@@ -46,7 +46,7 @@ void loop()
 // ---------- If the head of the service queue is dispatchable
 //            call the SERVICE.
 
-  if(serviceQueue != NULL && UTCTime() >= serviceQueue->callTime){
+  if(serviceQueue != NULL && UTCtime() >= serviceQueue->callTime){
     serviceBlock* thisBlock = serviceQueue;
     serviceQueue = thisBlock->next;
     ESP.wdtFeed();
@@ -108,7 +108,7 @@ void NewService(uint32_t (*serviceFunction)(struct serviceBlock*), const uint8_t
   }
 
 void AddService(struct serviceBlock* newBlock){
-  if(newBlock->callTime < UTCTime()) newBlock->callTime = UTCTime();
+  if(newBlock->callTime < UTCtime()) newBlock->callTime = UTCtime();
   if(serviceQueue == NULL ||
     (newBlock->callTime < serviceQueue->callTime) ||
     (newBlock->callTime == serviceQueue->callTime && newBlock->priority < serviceQueue->priority)){

--- a/Firmware/IotaWatt/Loop.cpp
+++ b/Firmware/IotaWatt/Loop.cpp
@@ -46,7 +46,7 @@ void loop()
 // ---------- If the head of the service queue is dispatchable
 //            call the SERVICE.
 
-  if(serviceQueue != NULL && UNIXtime() >= serviceQueue->callTime){
+  if(serviceQueue != NULL && UTCTime() >= serviceQueue->callTime){
     serviceBlock* thisBlock = serviceQueue;
     serviceQueue = thisBlock->next;
     ESP.wdtFeed();
@@ -108,7 +108,7 @@ void NewService(uint32_t (*serviceFunction)(struct serviceBlock*), const uint8_t
   }
 
 void AddService(struct serviceBlock* newBlock){
-  if(newBlock->callTime < UNIXtime()) newBlock->callTime = UNIXtime();
+  if(newBlock->callTime < UTCTime()) newBlock->callTime = UTCTime();
   if(serviceQueue == NULL ||
     (newBlock->callTime < serviceQueue->callTime) ||
     (newBlock->callTime == serviceQueue->callTime && newBlock->priority < serviceQueue->priority)){

--- a/Firmware/IotaWatt/PVoutput.cpp
+++ b/Firmware/IotaWatt/PVoutput.cpp
@@ -559,7 +559,7 @@ uint32_t PVoutput::tickUploadStatus(){
         delete newRecord;
         newRecord = nullptr;  
         trace(T_PVoutput,84);
-        Serial.printf("****************************\r\nbatch count %d, size %d, heap %d\r\n", _reqEntries, reqData.available(), ESP.getFreeHeap());
+        Serial.printf("PVoutput: batch count %d, size %d, heap %d\r\n", _reqEntries, reqData.available(), ESP.getFreeHeap());
         HTTPPost("addbatchstatus.jsp", "application/x-www-form-urlencoded", checkUploadStatus);
         _reqEntries = 0;
 

--- a/Firmware/IotaWatt/PVoutput.cpp
+++ b/Firmware/IotaWatt/PVoutput.cpp
@@ -1,0 +1,1079 @@
+#include "iotawatt.h"
+
+/******************************************************************************************************
+*    PVoutput server class, modeled after framework by Brendon Costa and updated to
+*    use newer facilities in IoTaWatt.  Thanks to Brendon for pioneering work,
+*    help sorting out the specifications, and configuration code.
+******************************************************************************************************/
+
+// null pointer until configured (or if deleted);
+
+PVoutput* pvoutput = nullptr;
+
+uint32_t PVoutputTick(struct serviceBlock* serviceBlock) {
+    trace(T_PVoutput,0);
+    if(pvoutput){
+        trace(T_PVoutput,1);
+        uint32_t reschedule = pvoutput->tick(serviceBlock);
+        trace(T_PVoutput,2);
+        if(reschedule){
+           return reschedule; 
+        } else {
+            log("PVoutput: Stopped.");
+            if(pvoutput) pvoutput->stop();
+        }
+        trace(T_PVoutput,3);
+    }
+    return 0;
+}
+
+        // stop() - At the first opportunity, enter _state = stopped and idle.
+
+void PVoutput::stop(){
+    _stop = true;
+    _restart = false;
+}
+
+        // restart() - At the first opportunity, restart the state sequence from the beginning (getSystemService)
+
+void PVoutput::restart(){
+    if(_state == stopped){
+        _restart = true;
+    } else {
+        _stop = false;
+        _restart = false;
+    }
+}
+
+        // end() - At the first opportunity, delete this instance of PVoutput
+
+void PVoutput::end(){
+    _end = true;
+}
+
+        // Get the current status as a Json object.
+
+void PVoutput::getStatusJson(JsonObject& status){
+    status.set(F("running"), (_started && _state != stopped));
+    status.set(F("lastpost"),local2UTC(_lastPostTime));
+}
+
+//********************************************************************************************************************
+//          
+//                                 TTTTT   III    CCC   K   K   
+//                                   T      I    C   C  K  K                   
+//                                   T      I    C      K K                  
+//                                   T      I    C   C  K  K                  
+//                                   T     III    CCC   K   K
+// 
+//******************************************************************************************************************/
+uint32_t PVoutput::tick(struct serviceBlock* serviceBlock){
+    trace(T_PVoutput,0);
+    switch (_state) {
+        case initialize:            {return tickInitialize();}
+        case getSystemService:      {return tickGetSystemService();}
+        case checkSystemService:    {return tickCheckSystemService();}
+        case gotSystemService:      {return tickGotSystemService();}
+        case getMissingList:        {return tickGetMissingList();}
+        case checkMissingList:      {return tickCheckMissingList();}
+        case gotMissingList:        {return tickGotMissingList();}
+        case uploadMissing:         {return tickUploadMissing();}
+        case checkUploadMissing:    {return tickCheckUploadMissing();}
+        case getStatus:             {return tickGetStatus();}
+        case gotStatus:             {return tickGotStatus();}
+        case uploadStatus:          {return tickUploadStatus();}
+        case checkUploadStatus:     {return tickCheckUploadStatus();}
+
+        case HTTPpost:              {return tickHTTPPost();}
+        case HTTPwait:              {return tickHTTPWait();}
+        case limitWait:             {return tickLimitWait();}
+        case stopped:               {return tickStopped();}
+    }
+    log("PVoutput: Unrecognize state, stopping");
+    return 0;
+}
+
+uint32_t PVoutput::tickStopped(){
+    if(_end){
+        pvoutput = nullptr;
+        delete this;
+        return 0;
+    }
+    if(_restart){
+        _restart = false;
+        _stop = false;
+        _state = getSystemService;
+        return 1; 
+    }
+    if(_stop){
+        return UTCtime() + 1;
+    }
+    _state = uploadStatus;
+    return 1;
+    
+}
+
+uint32_t PVoutput::tickInitialize(){
+    trace(T_PVoutput,10);
+    log("PVoutput: started");
+    _started = true;
+    _state = getSystemService;
+    return 1;
+}
+
+uint32_t PVoutput::tickGetSystemService(){
+    trace(T_PVoutput,20);
+    reqData.print("donations=1");
+    HTTPPost("getsystem.jsp", "application/x-www-form-urlencoded", checkSystemService);
+    reqData.flush();
+    return 1;
+}
+
+uint32_t PVoutput::tickCheckSystemService(){
+    trace(T_PVoutput,25);
+    switch (_HTTPresponse) {
+        case OK: {
+            _state = gotSystemService;
+            return 1;
+            }
+        case LOAD_IN_PROGRESS:
+        case RATE_LIMIT:
+        case HTTP_FAILURE: {
+            _state = getSystemService;
+            return 1;
+        }
+    }
+    log("PVoutput: Unrecognized HTTP completion, getSystemService %.40s", response->peek(40).c_str());
+    return 0;
+}
+
+uint32_t PVoutput::tickGotSystemService(){
+    trace(T_PVoutput,30);
+    _interval = response->parsel(0,15) * 60;
+    if(response->parsel(2,0)){
+        _donator = true;
+    }
+    log("PVoutput: System %s, interval %d%s  ", response->parseString(0,0).c_str(), _interval/60, _donator ? ", donator mode" : ", freeloader mode");
+    delete response;
+    response = nullptr;
+    _state = getMissingList;
+    return 1;
+}
+
+uint32_t PVoutput::tickGetMissingList(){
+    trace(T_PVoutput,40);
+    if( ! histLog.isOpen()){
+        return UTCtime() + 60;
+    }
+
+    uint32_t yesterday = localTime();
+    yesterday -= UNIX_DAY + yesterday % UNIX_DAY;
+    if(histLog.firstKey() > local2UTC(yesterday)){
+        _state = getStatus;
+        return 1;
+    }
+    trace(T_PVoutput,40);
+    if(_lastMissing == 0){
+        _lastMissing = UTC2Local(histLog.firstKey()) + UNIX_DAY;
+        _lastMissing -= _lastMissing % UNIX_DAY;
+        if(_beginPosting > _lastMissing){
+            _lastMissing = _beginPosting  - _beginPosting % UNIX_DAY;
+        }
+    }
+    trace(T_PVoutput,40);
+    if(_reload){
+        _missingQ = new missingQ;
+        _missingQ->first = _lastMissing;
+        _missingQ->last = yesterday;
+        _state = gotMissingList;
+        return 1;
+    }
+    Serial.printf("Last missing %s\r\n", datef(_lastMissing).c_str());
+    reqData.flush();
+    reqData.printf("df=%s&dt=%s", datef(_lastMissing, "YYYYMMDD").c_str(), datef(yesterday, "YYYYMMDD").c_str());
+    HTTPPost("getmissing.jsp", "application/x-www-form-urlencoded", checkMissingList);
+    return 1;
+}
+
+uint32_t PVoutput::tickCheckMissingList(){
+    trace(T_PVoutput,45);
+    switch (_HTTPresponse) {
+
+        default:{
+            log("PVoutput: Unrecognized HTTP completion, getMissing %.40s", response->peek(40).c_str());
+            return 0;
+        }
+        
+        case LOAD_IN_PROGRESS:
+        case RATE_LIMIT:
+        case HTTP_FAILURE: {
+            _state = getMissingList;
+            return 1;
+        }
+
+        case DATE_TOO_OLD:
+        case DATE_IN_FUTURE:
+        case OK: {
+            trace(T_PVoutput,50);
+            response->print();
+            int items = response->items();
+            Serial.printf("items %d\r\n", items);
+            for(int i=0; i<items; i++){
+                uint32_t date = response->parseDate(0,i);
+                if( ! _missingQ){
+                    _missingQ = new missingQ;
+                    _missingQ->first = date;
+                    _missingQ->last = date;
+                } 
+                else if(date == (_missingQ->last + UNIX_DAY)){
+                    _missingQ->last = date;
+                }
+                else {
+                    missingQ* link = _missingQ;
+                    _missingQ = new missingQ;
+                    _missingQ->next = link;
+                    _missingQ->first = date;
+                    _missingQ->last = date;
+                }
+            }
+            if(items == 50 ){
+                _lastMissing = _missingQ->last + UNIX_DAY;
+                _state = getMissingList;
+                return 1;
+            }
+            _state = gotMissingList;
+            return 1;
+        }
+    }
+}
+
+uint32_t PVoutput::tickGotMissingList(){
+    trace(T_PVoutput,50);
+    
+            // If nothing missing, skip ahead to getStatus.
+
+    if( ! _missingQ){
+        _state = getStatus;
+        return 1;
+    }
+
+            // List complete, convert from lifo to fifo.
+
+    trace(T_PVoutput,51);
+    
+    missingQ* _this = _missingQ;
+    missingQ* _next = _this->next;
+    _this->next = nullptr;
+    while(_next){
+        missingQ* _temp = _next->next;
+        _next->next = _this;
+        _this = _next;
+        _next = _temp;
+    }
+    _missingQ = _this;
+    
+
+            //  Display the missing queue.
+
+    missingQ* Qhead = _missingQ;
+    while(Qhead){
+        Serial.print(datef(Qhead->first, "MM/DD/YY"));
+        Serial.print(" - ");
+        Serial.println(datef(Qhead->last, "MM/DD/YY"));
+        Qhead = Qhead->next;
+    }
+    trace(T_PVoutput,52);
+
+    _lastPostTime = 0;
+    _reqEntries = 0;
+    _lastReqTime = _missingQ->first - UNIX_DAY;
+    reqData.flush();
+    _state = uploadMissing;
+    return 1;
+}
+
+uint32_t PVoutput::tickUploadMissing(){
+    trace(T_PVoutput,60);
+
+            // If buffer isn't full, get next request date (_lastReqTime)
+
+    missingQ* Qentry = _missingQ;
+    if(_reqEntries < (_donator ? PV_DONATOR_OUTPUT_LIMIT : PV_DEFAULT_OUTPUT_LIMIT)){
+        while(Qentry){
+            if(Qentry->last > _lastReqTime){
+                _lastReqTime += UNIX_DAY;
+                if(_lastReqTime < Qentry->first){
+                    _lastReqTime = Qentry->first;
+                }
+                break;
+            } 
+            Qentry = Qentry->next;
+        }
+    }
+
+            // If no more dates, or buffer is full, write out buffer.
+
+     if( ! Qentry || _reqEntries >= (_donator ? PV_DONATOR_OUTPUT_LIMIT : PV_DEFAULT_OUTPUT_LIMIT)){
+        trace(T_PVoutput,61);
+        if(_reqEntries){
+            Serial.printf("\r\nOutput %d\r\n", _reqEntries); 
+            _reqEntries = 0;
+            HTTPPost("addbatchoutput.jsp", "application/x-www-form-urlencoded", checkUploadMissing);
+            return 1;
+         }
+     }   
+        
+            // If queue is empty, and no current request
+            // We're done, advance to getStatus. 
+
+    if( ! Qentry && _reqEntries == 0){
+        trace(T_PVoutput,62);
+        delete _missingQ;
+        _missingQ = nullptr;
+        _state = getStatus;
+        return 1;
+    }
+
+            // Add new output to reqData.
+
+    trace(T_PVoutput,63);
+    if( ! newRecord) {
+        newRecord = new IotaLogRecord;
+    }
+    trace(T_PVoutput,64);
+    if(newRecord->UNIXtime == local2UTC(_lastReqTime)){
+        trace(T_PVoutput,64);
+        IotaLogRecord* temp = oldRecord;
+        oldRecord = newRecord;
+        newRecord = temp;
+    } else {
+        trace(T_PVoutput,65);    
+        oldRecord->UNIXtime = local2UTC(_lastReqTime);
+        if(histLog.readKey(oldRecord) != 0){
+            return 1;
+        }
+    }
+    trace(T_PVoutput,66);
+    newRecord->UNIXtime = local2UTC(_lastReqTime + UNIX_DAY);
+    if(histLog.readKey(newRecord) != 0){
+        return 1;
+    }
+
+            // Have bookend log records, create an output
+
+    trace(T_PVoutput,67);
+    double elapsedHours = newRecord->logHours - oldRecord->logHours;
+    if(elapsedHours == 0.0){
+        trace(T_PVoutput,67);
+        return 1;
+    }
+    if(reqData.available()){
+        reqData.print(';');
+        _reqEntries++;
+    } else {
+        reqData.print("data=");
+        _reqEntries = 1;
+    }
+    int32_t generation = 0;
+    int32_t consumption = 0;
+
+    trace(T_PVoutput,68);
+    Script* script = _outputs->first();
+    while(script){
+        double value = script->run(oldRecord, newRecord, elapsedHours, unitsWh);
+        if(strcmp(script->name(),"generation") == 0){
+            generation = value;
+        }
+        else if(strcmp(script->name(),"consumption") == 0){
+            consumption = value;    
+        }
+        script = script->next();
+    }
+    int32_t exported = generation - consumption;
+    if(exported < 0){
+        exported = 0;
+    }
+
+    trace(T_PVoutput,68);
+    reqData.printf_P(PSTR("%s,%d,%d,%d"), datef(_lastReqTime,"YYYYMMDD").c_str(), generation, exported, consumption, newRecord->logHours - oldRecord->logHours);
+
+    trace(T_PVoutput,68);
+    return 1;
+}
+
+uint32_t PVoutput::tickCheckUploadMissing(){
+    trace(T_PVoutput,69);
+    switch (_HTTPresponse) {
+        case DATE_TOO_OLD:
+        case DATE_IN_FUTURE:
+        case OK: {
+            _lastPostTime = _lastReqTime;   
+            _state = uploadMissing;
+            return 1;
+            }
+        case LOAD_IN_PROGRESS:
+        case RATE_LIMIT:
+        case HTTP_FAILURE: {
+            _lastReqTime = _lastPostTime;
+            _state = uploadMissing; 
+            return 1;
+        }
+    }
+    log("PVoutput: Unrecognized HTTP completion, uploadMissing %.40s", response->peek(40).c_str());
+    return 0;
+}
+
+uint32_t PVoutput::tickGetStatus(){
+    trace(T_PVoutput,70);
+    HTTPPost("getstatus.jsp", "application/x-www-form-urlencoded", gotStatus);
+    return 1;
+}
+
+uint32_t PVoutput::tickGotStatus(){
+    trace(T_PVoutput,75);
+    switch (_HTTPresponse) {
+        default: {
+            log("PVoutput: Unrecognized HTTP completion, gotStatus %.40s", response->peek(40).c_str());
+            return 0;
+        }
+        case LOAD_IN_PROGRESS:
+        case RATE_LIMIT:
+        case HTTP_FAILURE: {
+            _state = getStatus; 
+            return UTCtime() + 2;
+        }
+        case NO_STATUS: {
+            trace(T_PVoutput,76);
+            Serial.println("No Status");
+            _lastPostTime = 0;
+            break;
+        }
+        case OK: {
+            Serial.println("OK Status");
+            trace(T_PVoutput,77); 
+            _lastPostTime = response->parseDate(0,0) + response->parseTime(0,1);
+            break;
+        } 
+    }
+
+    trace(T_PVoutput,78);
+    uint32_t lookback = localTime() - UNIX_DAY * _donator ? PV_DONATOR_STATUS_DAYS : PV_DEFAULT_STATUS_DAYS;
+    lookback -= lookback % UNIX_DAY;
+    if(_lastPostTime < lookback || _reload){
+        _lastPostTime = lookback;
+    }
+    if(UTC2Local(histLog.firstKey()) > _lastPostTime){
+        _lastPostTime = UTC2Local(histLog.firstKey()) + _interval;
+        _lastPostTime -= _lastPostTime % _interval;
+    }
+    if(_lastPostTime < _beginPosting){
+        _lastPostTime = _beginPosting;
+    }
+
+    trace(T_PVoutput,78);
+    if(_reload){
+        log("PVoutput: Reload status beginning %s", datef(_lastPostTime + _interval).c_str());
+    } else {
+        log("PVoutput: Start status beginning %s", datef(_lastPostTime + _interval).c_str());
+    }
+    
+    trace(T_PVoutput,79);
+    delete response;
+    response = nullptr;
+    reqData.flush();
+    _reqEntries = 0;
+    _lastReqTime = _lastPostTime;
+    _state = uploadStatus;
+    return 1;
+    
+}
+        // uploadStatus()
+        // We have the (local) [date/]time of the last post in _lastPostTime.
+        // This gets tricky because the datalog is in UTC and we are posting in local time.
+        // Another wrinkle is that we use the power of the interval after the timestamp rather than before
+        // as in other services, so the posting will be delayed by interval. Another way to say that is
+        // we subtract interval to get the timestamp of each status.
+        // Report maximum statuses unless current where we revert to single writes.
+
+uint32_t PVoutput::tickUploadStatus(){
+    trace(T_PVoutput,80);
+
+            // This is the basic heartbeat of the service,
+            // and also a clean place to stop it,
+            // so check for a stop, restart, or end request.
+
+    if(_stop || _end){
+        trace(T_PVoutput,81);
+        delete oldRecord;
+        oldRecord = nullptr;
+        delete newRecord;
+        newRecord = nullptr;
+        delete request;
+        request = nullptr;
+        delete response;
+        response = nullptr;
+        _state = stopped;
+        return 1;
+    }
+
+    if(_restart){
+        trace(T_PVoutput,82);
+        _restart = false;
+        _state = getSystemService;
+        return 1;
+    }
+    
+            // Insure base energy values for the current day are set.
+
+    if(_baseTime != (_lastReqTime - _lastReqTime % UNIX_DAY)){
+        trace(T_PVoutput,83);
+        if( ! oldRecord){
+            oldRecord = new IotaLogRecord;
+        }
+        oldRecord->UNIXtime = local2UTC(_lastReqTime - _lastReqTime % UNIX_DAY);
+        histLog.readKey(oldRecord);
+        Script* script = _outputs->first();
+        while(script){
+            if(strcmp(script->name(),"generation") == 0){
+                _baseGeneration = script->run(nullptr, oldRecord, 1.0, unitsWh);
+            }
+            else if(strcmp(script->name(),"consumption") == 0){
+                _baseConsumption = script->run(nullptr, oldRecord, 1.0, unitsWh);
+            }
+            script = script->next();
+        }
+        _baseTime = _lastReqTime - _lastReqTime % UNIX_DAY;
+    }
+  
+            // Write buffer if not empty and any one of the following is true:
+            // Maximum enries per write
+            // Last entry is current
+            // Last entry is last entry for a day
+            
+    if(_reqEntries &&
+      (_reqEntries >= (_donator ? PV_DONATOR_STATUS_LIMIT : PV_DEFAULT_STATUS_LIMIT) ||
+      (_lastReqTime + _interval) > UTC2Local(histLog.lastKey()) ||
+      (_lastReqTime % UNIX_DAY) == 0)){
+        delete oldRecord;
+        oldRecord = nullptr;
+        delete newRecord;
+        newRecord = nullptr;  
+        trace(T_PVoutput,84);
+        Serial.printf("****************************\r\nbatch count %d, size %d, heap %d\r\n", _reqEntries, reqData.available(), ESP.getFreeHeap());
+        HTTPPost("addbatchstatus.jsp", "application/x-www-form-urlencoded", checkUploadStatus);
+        _reqEntries = 0;
+
+        // while(reqData.indexOf(';') > 0){
+        //     Serial.println(reqData.readStringUntil(';'));
+        // }
+        // Serial.println(reqData.readString());
+        // reqData.flush();
+        // _lastPostTime = _lastReqTime;
+
+        return 1;
+    }
+
+            // If up-to-date, just return.
+
+    if((_lastReqTime + _interval) > UTC2Local(histLog.lastKey())){
+        trace(T_PVoutput,85);
+        delete oldRecord;
+        oldRecord = nullptr;
+        delete newRecord;
+        newRecord = nullptr;
+        return UTCtime() + 1;
+    }
+
+            // Get the bracketing history log records (careful to convert to UTC)
+
+    if( ! oldRecord){
+        oldRecord = new IotaLogRecord;
+    }
+    if( ! newRecord) {
+        newRecord = new IotaLogRecord;
+    }
+    if(oldRecord->UNIXtime != local2UTC(_lastReqTime)){
+        trace(T_PVoutput,86);
+        if(newRecord->UNIXtime == local2UTC(_lastReqTime)){
+            IotaLogRecord* temp = oldRecord;
+            oldRecord = newRecord;
+            newRecord = temp;
+        } else {
+            oldRecord->UNIXtime = local2UTC(_lastReqTime);
+            histLog.readKey(oldRecord);
+        }
+    }
+    newRecord->UNIXtime = local2UTC(_lastReqTime + _interval);
+    histLog.readKey(newRecord);
+
+            // See if there was any measurement during this interval
+            // Skip ahead if not.
+
+    trace(T_PVoutput,87);
+    double elapsedHours = newRecord->logHours - oldRecord->logHours;
+    if(elapsedHours == 0.0){
+        _lastReqTime += _interval;
+        if(_reqEntries == 0){
+            _lastPostTime = _lastReqTime;
+        }
+        return 1;
+    }
+
+            // Got all the ingredients,
+            // prep reqData for new status.
+
+    trace(T_PVoutput,87);
+    if(_reqEntries++ == 0){
+        reqData.print("data=");
+    } else {
+        reqData.print(';');
+    }
+    reqData.printf_P("%s,%s", datef(_lastReqTime,"YYYYMMDD").c_str(), datef(_lastReqTime, "hh:mm").c_str());
+
+            // run the scripts to collect the data.
+
+    double powerGeneration(-1);
+    double powerConsumption(-1);
+    double voltage(-1);
+    double energyConsumption(-1);
+    double energyGeneration(-1);
+    double extended[6];
+    int    extendedPrecision[6];
+    int    lastExtended(-1); 
+    bool   haveExtended[6]{false,false,false,false,false,false};
+
+    Script* script = _outputs->first();
+    trace(T_PVoutput,88);
+    while(script){
+        if(strcmp(script->name(),"generation") == 0){
+            energyGeneration = script->run(nullptr, newRecord, 1.0, unitsWh) - _baseGeneration;
+            powerGeneration = script->run(oldRecord, newRecord, elapsedHours, unitsWatts);
+        }
+        else if(strcmp(script->name(),"consumption") == 0){
+            energyConsumption = script->run(nullptr, newRecord, 1.0, unitsWh) - _baseConsumption;
+            powerConsumption = script->run(oldRecord, newRecord, elapsedHours, unitsWatts);  
+        }
+        else if(strcmp(script->name(),"voltage") == 0){
+            voltage = script->run(oldRecord, newRecord, elapsedHours, unitsVolts);    
+        }
+        else if(strstr(script->name(),"extended_") == script->name()){
+            long ndx = strtol(script->name()+9,nullptr,10) - 1;
+            if(ndx >= 0 && ndx <=5){
+                if(ndx > lastExtended){
+                    lastExtended = ndx;
+                }
+                haveExtended[ndx] = true;
+                extended[ndx] = script->run(oldRecord, newRecord, elapsedHours);
+                extendedPrecision[ndx] = script->precision();
+            }
+        }
+        script = script->next();
+    }
+
+            // Add the collected data to the status
+
+    trace(T_PVoutput,88);
+    if(powerGeneration >= 0){
+        reqData.printf(",%.0f,%.0f", energyGeneration, powerGeneration);
+    } else {
+        reqData.print(",,");
+    }
+    if(powerConsumption >= 0){
+        reqData.printf(",%.0f,%.0f", energyConsumption, powerConsumption);
+    } else {
+        reqData.print(",,");
+    }
+    if(voltage >= 0){
+        reqData.printf(",,%.1f", voltage);
+    } else {
+        reqData.print(",,");
+    }
+    if(_donator && lastExtended >= 0){
+        for(int ndx=0; ndx<lastExtended; ndx++){
+            reqData.print(',');
+            if(haveExtended[ndx]){
+                reqData.printf("%.*f", extendedPrecision[ndx], extended[ndx]);
+            }
+        }
+    }
+
+            // Increment interval and do it again.
+
+    trace(T_PVoutput,89);
+    _lastReqTime += _interval;
+    return 1;
+}
+
+uint32_t PVoutput::tickCheckUploadStatus(){
+    trace(T_PVoutput,90);
+    switch (_HTTPresponse) {
+        default:{
+            log("PVoutput: Unrecognized HTTP completion, uploadMissing %.40s", response->peek(40).c_str());
+            return 0;
+        }
+        case DATE_TOO_OLD:
+        case DATE_IN_FUTURE:
+        case OK: {
+            trace(T_PVoutput,91);
+            _lastPostTime = _lastReqTime;   
+            _state = uploadStatus;
+            return 1;
+            }
+        case LOAD_IN_PROGRESS:
+        case RATE_LIMIT:
+        case HTTP_FAILURE: { // retry 
+            trace(T_PVoutput,92);           
+            _lastReqTime = _lastPostTime;
+            _state = uploadStatus; 
+            return 1;
+        }
+    }
+    }
+
+//********************************************************************************************************************
+//
+//                      H   H   TTTTT   TTTTT   PPPP
+//                      H   H     T       T     P   P
+//                      HHHHH     T       T     PPPP
+//                      H   H     T       T     P
+//                      H   H     T       T     P
+
+//*********************************************************************************************************************
+
+const char reqHeaderApikey[] = "X-Pvoutput-Apikey";
+const char reqHeaderRate[] = "X-Rate-Limit";
+const char reqHeaderSystemId[] = "X-Pvoutput-SystemId";
+const char respHeaderRemaining[] = "X-Rate-Limit-Remaining";
+const char respHeaderLimit[] = "X-Rate-Limit-Limit";
+const char respHeaderReset[] = "X-Rate-Limit-Reset";
+const char reqHeaderContentType[] = "Content-type";
+
+void PVoutput::HTTPPost(const char* URI, const char* contentType, states completionState){
+    trace(T_PVoutput,100);
+    if( ! _POSTrequest){
+        _POSTrequest = new POSTrequest;
+    }
+    delete _POSTrequest->URI;
+    _POSTrequest->URI = charstar(URI);
+    delete _POSTrequest->contentType;
+    _POSTrequest->contentType = charstar(contentType);
+    _POSTrequest->completionState = completionState;
+    _state = HTTPpost;
+}
+
+uint32_t PVoutput::tickHTTPPost(){
+    trace(T_PVoutput,110);
+    if(_rateLimitRemaining <= 0  && UTCtime() < _rateLimitReset){
+        log("PVoutput: Transaction Rate-Limit exceeded.  Waiting until %s", datef(UTC2Local(_rateLimitReset), "hh:mm").c_str());
+        _state = limitWait;
+        return 1;
+    }
+    if( ! WiFi.isConnected()){
+        return UTCtime() + 1;
+    }
+    _HTTPtoken = HTTPreserve(T_influx);
+    if( ! _HTTPtoken){
+        return 1;
+    }
+    if( ! request){
+        request = new asyncHTTPrequest;
+    }
+    request->setTimeout(3);
+    request->setDebug(false);
+    char URL[128];
+    size_t len = sprintf_P(URL, PSTR("HTTP://pvoutput.org/service/r2/%s"), _POSTrequest->URI);
+    if( ! request->open("POST", URL)){
+        HTTPrelease(_HTTPtoken);
+        return UTCtime() + 10;
+    }
+    request->setReqHeader(reqHeaderApikey, _apiKey);
+    request->setReqHeader(reqHeaderSystemId, _systemID);
+    request->setReqHeader(reqHeaderRate, "1");
+    if(_POSTrequest->contentType){
+        request->setReqHeader(reqHeaderContentType, _POSTrequest->contentType);
+    }
+    if(reqData.available()){
+        request->send(&reqData, reqData.available());
+    } else {
+        request->send();
+    }
+    _state = HTTPwait;
+    return 1;
+}
+
+uint32_t PVoutput::tickHTTPWait(){
+    trace(T_PVoutput,120);
+    if(request->readyState() != 4){
+        return 1;
+    }
+    HTTPrelease(_HTTPtoken);
+    _state = _POSTrequest->completionState;
+    //delete _POSTrequest;
+    //_POSTrequest = nullptr;
+    trace(T_PVoutput,121);
+
+            // Get the flow control headers from PVoutput
+
+    trace(T_PVoutput,120);
+    if(request->respHeaderExists(respHeaderLimit)){
+        _rateLimitLimit = strtol(request->respHeaderValue(respHeaderLimit),nullptr,10);
+    }
+    if(request->respHeaderExists(respHeaderRemaining)){
+        _rateLimitRemaining = strtol(request->respHeaderValue(respHeaderRemaining),nullptr,10);
+    }
+    if(request->respHeaderExists(respHeaderReset)){
+        _rateLimitReset = strtoul(request->respHeaderValue(respHeaderReset),nullptr,10);
+    }
+    trace(T_PVoutput,122);
+
+            // If communication failure,
+            // Set completion 
+
+    trace(T_PVoutput,120);
+    if(request->responseHTTPcode() < 0){
+        _HTTPresponse = HTTP_FAILURE;
+        return UTCtime() + 1;
+    }
+    trace(T_PVoutput,122);
+
+            // Capture response.
+
+    trace(T_PVoutput,121);
+    
+    // if(_state == checkUploadStatus){
+    //     delete response;
+    //     response = nullptr;
+    // } else {
+        delete response;
+        response = new PVresponse(request); 
+    // }
+    
+    
+            // Put out Serial diagnostics
+
+    //Serial.printf_P(PSTR("HTTP response %d, length %d, %.40s\r\n"), request->responseHTTPcode(), response->length(), response->peek(40).c_str());
+    //Serial.printf_P(PSTR("Limit %d, Remaining %d, Reset %s\r\n"), _rateLimitLimit, _rateLimitRemaining, datef(UTC2Local(_rateLimitReset)).c_str());
+    trace(T_PVoutput,122);
+
+            // Interpret response code.
+
+    if(request->responseHTTPcode() == 200){
+        trace(T_PVoutput,122);
+        _HTTPresponse = OK;
+        return 1;
+    }
+    
+    if(request->responseHTTPcode() == 403 && response->contains(F("Exceeded")) && response->contains(F("requests per hour"))){
+        trace(T_PVoutput,123);
+        log("PVoutput: Transaction Rate-Limit exceeded.  Waiting until %s", datef(UTC2Local(_rateLimitReset), "hh:mm").c_str());
+        _HTTPresponse = RATE_LIMIT;        
+        return 1;
+    }
+
+    if(request->responseHTTPcode() == 400){
+        trace(T_PVoutput,124);
+        if(response->contains(F("Load in progress"))){
+            _HTTPresponse = LOAD_IN_PROGRESS;
+            return UTCtime() + 30;
+        }
+        if(response->contains(F("Date is in the future"))){
+            _HTTPresponse = DATE_IN_FUTURE;
+            return 1;
+        }
+        if(response->contains(F("Date is older than"))){
+            _HTTPresponse = DATE_TOO_OLD;
+            return 1;
+        }
+        if(response->contains(F("Moon powered"))){
+            _HTTPresponse = MOON_POWERED;
+            return 1;
+        }
+        if(response->contains(F("No status"))){
+            _HTTPresponse = NO_STATUS;
+            return 1;
+        }
+    }
+
+                // No recovery from other responses.
+    
+    log("PVoutput: Fatal response %s", request->responseText().c_str());
+    Serial.println(response->peek(response->length()));
+    return 0;
+}
+
+uint32_t PVoutput::tickLimitWait(){
+    if(UTCtime() > _rateLimitReset){
+        trace(T_PVoutput,131);
+        Serial.printf("waitLimit UTC %s, reset %s\r\n", datef(UTCtime()).c_str(), datef(_rateLimitReset).c_str());
+        _state = HTTPpost;
+        return 1;
+    }
+    trace(T_PVoutput,130);
+    return UTCtime() + 5;
+}
+
+//********************************************************************************************************************
+//
+//               CCC     OOO    N   N   FFFFF   III    GGG
+//              C   C   O   O   NN  N   F        I    G   
+//              C       O   O   N N N   FFF      I    G  GG
+//              C   C   O   O   N  NN   F        I    G   G
+//               CCC     OOO    N   N   F       III    GGG
+//
+//********************************************************************************************************************
+bool PVoutput::config(const char* configObj){
+    DynamicJsonBuffer Json;
+    JsonObject& config = Json.parseObject(configObj);
+    if( ! config.success()){
+        log("PVoutput: Json parse failed.");
+        return false; 
+    }
+    trace(T_PVoutput,200);
+    if(config["type"].as<String>() != "pvoutput"){
+        return false;
+    }
+    trace(T_PVoutput,201);
+    if(_revision == config["revision"]){
+        return true;
+    }
+    _revision = config["revision"];
+    _reload = config["reload"].as<bool>();
+    if(_reload && _started){
+        _restart = true;
+    }
+    _stop = config["stop"].as<bool>();
+    trace(T_PVoutput,202);
+    _beginPosting = config.get<uint32_t>("begdate");
+    delete[] _apiKey;
+    _apiKey = charstar(config["apikey"].as<char*>());
+    delete[] _systemID;
+    _systemID = charstar(config["systemid"].as<char*>());
+    trace(T_PVoutput,203);
+    delete _outputs;
+    JsonVariant var = config["outputs"];
+    if(var.success()){
+        trace(T_PVoutput,204);
+        _outputs = new ScriptSet(var.as<JsonArray>());
+    }
+    trace(T_PVoutput,205);
+    if( ! _started) {
+        trace(T_PVoutput,206);
+        NewService(PVoutputTick, T_PVoutput);
+        _started = true;
+    }
+    trace(T_PVoutput,207);
+    return true; 
+}
+
+//******************************************************************************************************************
+//
+//              PPPP    V   V   RRRR    EEEEE    SSS    PPPP     OOO    N   N    SSS    EEEEE
+//              P   P   V   V   R   R   E       S       P   P   O   O   NN  N   S       E
+//              PPPP    V   V   RRRR    EEEE     SSS    PPPP    O   O   N N N    SSS    EEEE
+//              P        V V    R  R    E           S   P       O   O   N  NN       S   E
+//              P         V     R   R   EEEEE    SSS    P        OOO    N   N    SSS    EEEEE
+//
+//******************************************************************************************************************
+
+PVresponse::PVresponse(asyncHTTPrequest* request){
+    _response = new char[request->available()+1];
+    _response[request->available()] = 0;
+    request->responseRead((uint8_t*)_response, request->available());
+}
+
+PVresponse::~PVresponse(){
+    delete[] _response;
+}
+
+size_t  PVresponse::sections(){
+    char* pointer = _response;
+    if(*pointer == 0) return 0;
+    size_t section = 0;
+    while(*pointer){
+        if(*(pointer++) == ';') section++;
+    }
+    return section + 1;
+}
+
+size_t PVresponse::items(int section){
+    char* pointer = parsePointer(section, 0);
+    if( ! pointer || *pointer == 0) return 0;
+    size_t item = 0;
+    while(*pointer){
+        if(*(pointer) == ';') break;
+        if(*(pointer++) == ',') item++;
+    }
+    return item + 1;
+}
+
+char* PVresponse::parsePointer(int section, int item){
+    char* pointer = _response;
+    while(section){
+        if( ! *pointer) return nullptr;
+        if(*(pointer++) == ';') section--;
+    }
+    while(item){
+        if( ! *pointer) return nullptr;
+        if(*(pointer++) == ',') item--;
+    }
+    return pointer;
+}
+
+int32_t     PVresponse::parsel(int section, int item){
+    char* pointer = parsePointer(section, item);
+    if( ! pointer) return 0;
+    return strtol(pointer, nullptr, 10);
+}
+
+uint32_t    PVresponse::parseul(int section, int item){
+    char* pointer = parsePointer(section, item);
+    if( ! pointer) return 0;
+    return strtoul(pointer, nullptr, 10);
+}
+
+String      PVresponse::parseString(int section, int item){
+    char* pointer = parsePointer(section, item);
+    String str;
+    while(*pointer && *pointer != ',' && *pointer != ';'){
+        str += *(pointer++);
+    }
+    return str;
+}
+
+uint32_t    PVresponse::parseDate(int section, int item){
+    char* pointer = parsePointer(section, item);
+    return YYYYMMDD2Unixtime(parseString(section, item).c_str());
+}
+
+uint32_t    PVresponse::parseTime(int section, int item){
+    char* pointer = parsePointer(section, item);
+    return HHMMSS2daytime(parseString(section, item).c_str(), "%2d:%2d");
+}
+
+void    PVresponse::print(){
+    Serial.println(_response);
+}
+
+String  PVresponse::peek(int length, int offset){
+    int len = strlen(_response);
+    if(offset >= len) return String();
+    if((length + offset) > len){
+        length = len - offset;
+    }
+    char* str = new char[length+1];
+    memcpy(str, _response+offset, length);
+    str[length] = 0;
+    return String(str);
+}
+
+size_t  PVresponse::length(){
+    return strlen(_response);
+}
+
+bool    PVresponse::contains(const char* string){
+    return strstr(_response, string);
+}
+
+bool    PVresponse::contains(const __FlashStringHelper *str){
+    return strstr_P(_response, (PGM_P)str);
+}

--- a/Firmware/IotaWatt/PVoutput.h
+++ b/Firmware/IotaWatt/PVoutput.h
@@ -1,0 +1,201 @@
+#pragma once
+#include "IotaWatt.h"
+
+#define UNIX_DAY 86400UL
+#define PV_MISSING_LIMIT 50                         // maximum missing outputs returned in one request
+#define PV_DEFAULT_RATE_LIMIT 60                    // writes per hour default
+#define PV_DONATOR_RATE_LIMIT 300                   // writes per hour donator
+#define PV_DEFAULT_OUTPUT_LIMIT 30                  // max outputs added per batch default
+#define PV_DONATOR_OUTPUT_LIMIT 100                 // max outputs added per batch donator
+#define PV_DEFAULT_STATUS_LIMIT 30                  // max status added per batch default
+#define PV_DONATOR_STATUS_LIMIT 100                 // max status added per batch donator
+#define PV_DEFAULT_STATUS_DAYS 14                   // max status update lookback days default
+#define PV_DONATOR_STATUS_DAYS 90                   // max status update lookback days donator
+
+class PVresponse {
+    private:
+        char*       _response;
+
+    public:
+        PVresponse(asyncHTTPrequest* request);
+        ~PVresponse();
+        size_t      sections();
+        size_t      items(int section=0);
+        int32_t     parsel(int section, int item);
+        uint32_t    parseul(int section, int item);
+        String      parseString(int section, int item);
+        char*       parsePointer(int section, int item);
+        uint32_t    parseDate(int section, int item);
+        uint32_t    parseTime(int section, int item);
+        void        print();
+        String      peek(int length, int offset=0);
+        size_t      length();
+        bool        contains(const char *str);
+        bool        contains(const __FlashStringHelper *str);
+    
+ };
+
+class PVoutput {
+
+public:
+
+    PVoutput()
+        :_interval(0)
+        ,_apiKey(nullptr)
+        ,_systemID(nullptr)
+        ,_revision(-1)
+        ,_beginPosting(0)
+        ,_lastMissing(0)
+        ,_missingQ(nullptr)
+        ,_state(initialize)
+        ,_started(false)
+        ,_stop(false)
+        ,_restart(false)
+        ,_end(false)
+        ,_donator(false)
+        ,_reload(false)
+        ,_HTTPtoken(0)
+        ,_outputs(nullptr)
+        ,request(nullptr)
+        ,response(nullptr)
+        ,_lastPostTime(0)
+        ,_lastReqTime(0)
+        ,oldRecord(new IotaLogRecord)
+        ,newRecord(nullptr)
+        ,_POSTrequest(nullptr)
+        ,_rateLimitReset(0)
+        ,_baseTime(0)
+        {};
+
+    ~PVoutput(){
+        delete _missingQ;
+        delete[] _apiKey;
+        delete oldRecord;
+        delete newRecord;
+        delete _outputs;
+        delete request;
+        delete response;
+        delete _POSTrequest;
+    };
+
+    bool config(const char* jsonText);
+    void stop();
+    void end();
+    void restart();
+    void getStatusJson(JsonObject&);
+    uint32_t tick(struct serviceBlock* serviceBlock);
+
+private:
+
+    enum    states     {initialize, 
+                        getSystemService,
+                        checkSystemService,
+                        gotSystemService,
+                        getMissingList,
+                        checkMissingList,
+                        gotMissingList,
+                        uploadMissing,
+                        checkUploadMissing,
+                        getStatus,
+                        gotStatus,
+                        uploadStatus,
+                        checkUploadStatus, 
+                        HTTPpost, 
+                        HTTPwait,
+                        limitWait,
+                        stopped,
+                        noRetry
+                    } _state;
+
+    enum HTTPresponses {OK,
+                        LOAD_IN_PROGRESS,
+                        DATE_TOO_OLD,
+                        DATE_IN_FUTURE,
+                        RATE_LIMIT,
+                        NO_STATUS,
+                        MOON_POWERED,
+                        HTTP_FAILURE
+                    } _HTTPresponse;
+
+    struct      POSTrequest{
+        char*   URI;
+        char*   contentType;
+        states  completionState;
+        POSTrequest():URI(nullptr),contentType(nullptr){};
+        ~POSTrequest(){delete[] URI; delete[] contentType;}
+    };
+
+    struct      missingQ {
+        missingQ*   next;
+        uint32_t    first;
+        uint32_t    last;
+        missingQ():next(nullptr), first(0), last(0){};
+        ~missingQ(){delete next;};
+    };
+    
+    uint16_t    _interval;                  // Status interval from getSystemService
+    char*       _apiKey;                    // From configuration
+    char*       _systemID;                  // From configuration
+    int32_t     _revision;                  // Configuration change identifier
+    uint32_t    _beginPosting;              // Earliest date to begin posting as appropriate
+    uint32_t    _lastMissing;               // Used for context while building missing outputs list
+    missingQ*   _missingQ;                  // Head of queue of missing outputs
+    bool        _started;                   // Initialization has been completed
+    bool        _stop;                      // Set to stop and idle (_state = stopped) ASAP    
+    bool        _restart;                   // Restart by setting (_state = getSystemService) ASAP
+    bool        _end;                       // End the service and delete the instance of PVoutput ASAP
+    bool        _donator;                   // PVoutput indicates donation made in getSystemService
+    bool        _reload;                    // Reload all PVoutput data from _beginPosting as appropriate             
+    uint32_t    _HTTPtoken;                 // Token used as identifier for HTTP subsystem resource          
+    ScriptSet*  _outputs;                   // Output scripts
+    asyncHTTPrequest* request;              // Instance of asyncHTTPrequest used for HTTP GET/PUT
+    PVresponse* response;                   // Instance of response class used to parse response data
+    xbuf        reqData;                    // Instance of xbuf used to build output and status batches
+    uint32_t    _lastPostTime;              // Local time of last output or status posted to PVoutput
+    uint32_t    _lastReqTime;               // Local time of last output or status in reqData or posted not confirmed
+    IotaLogRecord* oldRecord;               // Older of two log records bracketing a reporting interval
+    IotaLogRecord* newRecord;               // Newer of two log records bracketing a reporting interval    
+    POSTrequest* _POSTrequest;              // Details of active POST request
+
+    int32_t     _rateLimitLimit;            // Flow control from PVoutput response headers
+    int32_t     _rateLimitRemaining;
+    uint32_t    _rateLimitReset;            // UTC time when rate limit will be reset
+
+    int         _reqEntries;                // Output or status entries in reqData
+    double      _baseConsumption;           // Energy consumption at start of current reporting day
+    double      _baseGeneration;            // Energy generation at start of current reporting day
+    uint32_t    _baseTime;                  // Local date (UNIXtime 00:00:00) of above base values
+
+    uint32_t    tickInitialize();
+    uint32_t    tickGetSystemService();
+    uint32_t    tickCheckSystemService();
+    uint32_t    tickGotSystemService();
+    uint32_t    tickGetMissingList();
+    uint32_t    tickCheckMissingList();
+    uint32_t    tickGotMissingList();
+    uint32_t    tickUploadMissing();
+    uint32_t    tickCheckUploadMissing();
+    uint32_t    tickGetStatus();
+    uint32_t    tickGotStatus();
+    uint32_t    tickUploadStatus();
+    uint32_t    tickCheckUploadStatus();
+    uint32_t    tickHTTPPost();
+    uint32_t    tickHTTPWait();
+    uint32_t    tickLimitWait();
+    uint32_t    tickStopped();
+
+    void        HTTPPost(const char* URI, const char* contentType, states completionState);
+    
+enum        HTTP_status {
+                    HTTP_SUCCESS,
+                    HTTP_LIMIT,
+                    HTTP_DONATOR,
+                    HTTP_INVALID
+                    } _HTTP_status;
+
+};
+
+extern PVoutput* pvoutput;
+
+uint32_t PVOutputTick(struct serviceBlock* serviceBlock);
+   

--- a/Firmware/IotaWatt/Setup.cpp
+++ b/Firmware/IotaWatt/Setup.cpp
@@ -65,7 +65,7 @@ void setup()
     timeRefNTP = rtc.now().unixtime() + SEVENTY_YEAR_SECONDS;
     timeRefMs = millis();
     RTCrunning = true;
-    log("Real Time Clock is running. Unix time %d ", UTCTime());
+    log("Real Time Clock is running. Unix time %d ", UTCtime());
     if((Control_3 & 0x08) != 0){
       log("Power failure detected.");
       Wire.beginTransmission(PCF8523_ADDRESS);            
@@ -78,7 +78,7 @@ void setup()
   else {
     log("Real Time Clock not initialized.");
   }
-  programStartTime = UTCTime();
+  programStartTime = UTCtime();
   
   Wire.beginTransmission(PCF8523_ADDRESS);            // Set crystal load capacitance
   Wire.write((byte)0);

--- a/Firmware/IotaWatt/Setup.cpp
+++ b/Firmware/IotaWatt/Setup.cpp
@@ -65,7 +65,7 @@ void setup()
     timeRefNTP = rtc.now().unixtime() + SEVENTY_YEAR_SECONDS;
     timeRefMs = millis();
     RTCrunning = true;
-    log("Real Time Clock is running. Unix time %d ", UNIXtime());
+    log("Real Time Clock is running. Unix time %d ", UTCTime());
     if((Control_3 & 0x08) != 0){
       log("Power failure detected.");
       Wire.beginTransmission(PCF8523_ADDRESS);            
@@ -78,7 +78,7 @@ void setup()
   else {
     log("Real Time Clock not initialized.");
   }
-  programStartTime = UNIXtime();
+  programStartTime = UTCTime();
   
   Wire.beginTransmission(PCF8523_ADDRESS);            // Set crystal load capacitance
   Wire.write((byte)0);

--- a/Firmware/IotaWatt/WiFi.cpp
+++ b/Firmware/IotaWatt/WiFi.cpp
@@ -71,7 +71,7 @@ uint32_t WiFiService(struct serviceBlock* _serviceBlock) {
     }
   }
  
-  return UNIXtime() + 1;  
+  return UTCTime() + 1;  
 }
 
 uint32_t HTTPreserve(uint16_t id, bool lock){

--- a/Firmware/IotaWatt/WiFi.cpp
+++ b/Firmware/IotaWatt/WiFi.cpp
@@ -71,7 +71,7 @@ uint32_t WiFiService(struct serviceBlock* _serviceBlock) {
     }
   }
  
-  return UTCTime() + 1;  
+  return UTCtime() + 1;  
 }
 
 uint32_t HTTPreserve(uint16_t id, bool lock){

--- a/Firmware/IotaWatt/auth.cpp
+++ b/Firmware/IotaWatt/auth.cpp
@@ -72,7 +72,7 @@ bool auth(authLevel level){
       md5.calculate();
       String _responsecheck = md5.toString();
       if(_response == _responsecheck){
-        session->lastUsed = UTCTime();  
+        session->lastUsed = UTCtime();  
         return true;
       }
     }
@@ -110,7 +110,7 @@ authSession* newAuthSession(){
     session->next = new authSession;
     session = session->next;
     session->IP = server.client().remoteIP();
-    session->lastUsed = UTCTime();
+    session->lastUsed = UTCtime();
     getNonce(session->nonce);
     return session;
 }
@@ -136,7 +136,7 @@ authSession* getAuthSession(const char* nonce, const char* nc){
 void  purgeAuthSessions(){
     authSession* session = (authSession*)&authSessions;
     while(session->next){
-        if((session->next->lastUsed + 600) < UTCTime()){
+        if((session->next->lastUsed + 600) < UTCtime()){
             authSession* expSession = session->next;
             session->next = expSession->next;
             delete expSession;

--- a/Firmware/IotaWatt/auth.cpp
+++ b/Firmware/IotaWatt/auth.cpp
@@ -72,7 +72,7 @@ bool auth(authLevel level){
       md5.calculate();
       String _responsecheck = md5.toString();
       if(_response == _responsecheck){
-        session->lastUsed = UNIXtime();  
+        session->lastUsed = UTCTime();  
         return true;
       }
     }
@@ -110,7 +110,7 @@ authSession* newAuthSession(){
     session->next = new authSession;
     session = session->next;
     session->IP = server.client().remoteIP();
-    session->lastUsed = UNIXtime();
+    session->lastUsed = UTCTime();
     getNonce(session->nonce);
     return session;
 }
@@ -136,7 +136,7 @@ authSession* getAuthSession(const char* nonce, const char* nc){
 void  purgeAuthSessions(){
     authSession* session = (authSession*)&authSessions;
     while(session->next){
-        if((session->next->lastUsed + 600) < UNIXtime()){
+        if((session->next->lastUsed + 600) < UTCTime()){
             authSession* expSession = session->next;
             session->next = expSession->next;
             delete expSession;

--- a/Firmware/IotaWatt/dataLog.cpp
+++ b/Firmware/IotaWatt/dataLog.cpp
@@ -62,13 +62,13 @@
         if(histLog.begin(historyLogFile) == 0 && histLog.fileSize() > 0){
           logRecord->UNIXtime = histLog.lastKey();
           histLog.readKey(logRecord);
-          log("dataLog: Last history entry: %s", localDateString(logRecord->UNIXtime).c_str());
+          log("dataLog: Last history entry: %s", datef(UTC2Local(logRecord->UNIXtime)).c_str());
         }
       }
       else {
         logRecord->UNIXtime = currLog.lastKey();
         currLog.readKey(logRecord);
-        log("dataLog: Last log entry %s", localDateString(currLog.lastKey()).c_str());
+        log("dataLog: Last log entry %s", datef(UTC2Local(currLog.lastKey())).c_str());
       }
 
       state = checkClock;
@@ -93,8 +93,8 @@
 
       // If it's been a long time since last entry, skip ahead.
       
-      if((UNIXtime() - logRecord->UNIXtime) > GapFill){
-        logRecord->UNIXtime = UNIXtime() - UNIXtime() % currLog.interval();
+      if((UTCTime() - logRecord->UNIXtime) > GapFill){
+        logRecord->UNIXtime = UTCTime() - UTCTime() % currLog.interval();
       }
 
       // Initialize timeNext (will be incremented at exit below)
@@ -110,11 +110,11 @@
 
       // If this seems premature.... get outta here.
 
-      if(UNIXtime() < timeNext) return timeNext;
+      if(UTCTime() < timeNext) return timeNext;
 
       // If log is up to date, update the entry with latest data.
           
-      if(timeNext >= (UNIXtime() - UNIXtime() % currLog.interval())){
+      if(timeNext >= (UTCTime() - UTCTime() % currLog.interval())){
         double elapsedHrs = double((uint32_t)(timeNow - timeThen)) / MS_PER_HOUR;
         for(int i=0; i<maxInputs; i++){
           IotaInputChannel* _input = inputChannel[i];

--- a/Firmware/IotaWatt/dataLog.cpp
+++ b/Firmware/IotaWatt/dataLog.cpp
@@ -93,8 +93,8 @@
 
       // If it's been a long time since last entry, skip ahead.
       
-      if((UTCTime() - logRecord->UNIXtime) > GapFill){
-        logRecord->UNIXtime = UTCTime() - UTCTime() % currLog.interval();
+      if((UTCtime() - logRecord->UNIXtime) > GapFill){
+        logRecord->UNIXtime = UTCtime() - UTCtime() % currLog.interval();
       }
 
       // Initialize timeNext (will be incremented at exit below)
@@ -110,11 +110,11 @@
 
       // If this seems premature.... get outta here.
 
-      if(UTCTime() < timeNext) return timeNext;
+      if(UTCtime() < timeNext) return timeNext;
 
       // If log is up to date, update the entry with latest data.
           
-      if(timeNext >= (UTCTime() - UTCTime() % currLog.interval())){
+      if(timeNext >= (UTCtime() - UTCtime() % currLog.interval())){
         double elapsedHrs = double((uint32_t)(timeNow - timeThen)) / MS_PER_HOUR;
         for(int i=0; i<maxInputs; i++){
           IotaInputChannel* _input = inputChannel[i];

--- a/Firmware/IotaWatt/eMonService.cpp
+++ b/Firmware/IotaWatt/eMonService.cpp
@@ -81,7 +81,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
           // so wait until the log service is up and running.
       
       if(!currLog.isOpen()){
-        return UTCTime() + 5;
+        return UTCtime() + 5;
       }
       log("EmonService: started. url=%s:%d%s, node=%s, interval=%d%s", EmonURL, EmonPort, EmonURI, 
            emonNode, EmonCMSInterval, (EmonSend == EmonSendGET ? "" : ", encrypted"));
@@ -94,11 +94,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
     case queryLastGet: {
       trace(T_Emon,3);
       if(! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -115,26 +115,26 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
       trace(T_Emon,3);
       request->send();
       state = queryLastWait;
-      return UTCTime() + 1;
+      return UTCtime() + 1;
     } 
 
     case queryLastWait: {
       trace(T_Emon,4);
       if(request->readyState() != 4){
-        return UTCTime() + 1; 
+        return UTCtime() + 1; 
       }
       HTTPrelease(HTTPtoken);
       trace(T_Emon,4);
       if(request->responseHTTPcode() != 200){
         state = queryLastGet;
         if(++retryCount < 10){
-          return UTCTime() + 1;
+          return UTCtime() + 1;
         }
         if(retryCount == 10){
           log("EmonService: get input list failing, code: %d", request->responseHTTPcode());
           Serial.println(request->responseText());
         }
-        return UTCTime() + 30;
+        return UTCtime() + 30;
       }
 
       trace(T_Emon,4);    
@@ -228,7 +228,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
           // If not enough entries for bulk-send, come back in one second;
 
       if(((currLog.lastKey() - EmonLastPost) / EmonCMSInterval + reqEntries) < EmonBulkSend){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
 
           // If buffer isn't full,
@@ -336,11 +336,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
     case sendPost:{
       trace(T_Emon,7);
       if( ! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -367,11 +367,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
 case sendSecure:{
       trace(T_Emon,9);
       if( ! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       if( ! request) {
         request = new asyncHTTPrequest;
@@ -449,7 +449,7 @@ case sendSecure:{
       if( ! request->open("POST", URL.c_str())){
         HTTPrelease(HTTPtoken);
         state = getLastRecord;
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       trace(T_Emon,10);
       request->setReqHeader("Content-Type","aes128cbc");
@@ -474,7 +474,7 @@ case sendSecure:{
             log("EmonService: HTTP response %d, retrying.", request->responseHTTPcode());
         }
         state = getLastRecord;
-        return UTCTime() + retryCount / 10;
+        return UTCtime() + retryCount / 10;
       }
       trace(T_Emon,11);
       String response = request->responseText();
@@ -487,7 +487,7 @@ case sendSecure:{
           EmonLastPost = reqUnixtime;
         }
         state = getLastRecord;
-        return UTCTime() + retryCount / 10;
+        return UTCtime() + retryCount / 10;
       }
       trace(T_Emon,11);
       if(retryCount >= 3){

--- a/Firmware/IotaWatt/eMonService.cpp
+++ b/Firmware/IotaWatt/eMonService.cpp
@@ -81,7 +81,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
           // so wait until the log service is up and running.
       
       if(!currLog.isOpen()){
-        return UNIXtime() + 5;
+        return UTCTime() + 5;
       }
       log("EmonService: started. url=%s:%d%s, node=%s, interval=%d%s", EmonURL, EmonPort, EmonURI, 
            emonNode, EmonCMSInterval, (EmonSend == EmonSendGET ? "" : ", encrypted"));
@@ -94,11 +94,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
     case queryLastGet: {
       trace(T_Emon,3);
       if(! WiFi.isConnected()){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -115,25 +115,26 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
       trace(T_Emon,3);
       request->send();
       state = queryLastWait;
-      return UNIXtime() + 1;
+      return UTCTime() + 1;
     } 
 
     case queryLastWait: {
       trace(T_Emon,4);
       if(request->readyState() != 4){
-        return UNIXtime() + 1; 
+        return UTCTime() + 1; 
       }
       HTTPrelease(HTTPtoken);
       trace(T_Emon,4);
       if(request->responseHTTPcode() != 200){
         state = queryLastGet;
         if(++retryCount < 10){
-          return UNIXtime() + 1;
+          return UTCTime() + 1;
         }
         if(retryCount == 10){
           log("EmonService: get input list failing, code: %d", request->responseHTTPcode());
+          Serial.println(request->responseText());
         }
-        return UNIXtime() + 30;
+        return UTCTime() + 30;
       }
 
       trace(T_Emon,4);    
@@ -227,7 +228,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
           // If not enough entries for bulk-send, come back in one second;
 
       if(((currLog.lastKey() - EmonLastPost) / EmonCMSInterval + reqEntries) < EmonBulkSend){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
 
           // If buffer isn't full,
@@ -335,11 +336,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
     case sendPost:{
       trace(T_Emon,7);
       if( ! WiFi.isConnected()){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -349,9 +350,7 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
       request->setTimeout(2);
       request->setDebug(false);
       if(request->debug()){
-        DateTime now = DateTime(localUNIXtime());
-        String msg = timeString(now.hour()) + ':' + timeString(now.minute()) + ':' + timeString(now.second());
-        Serial.println(msg);
+        Serial.println(datef(localTime(),"hh:mm:ss"));
       }
       request->open("POST", URL.c_str());
       trace(T_Emon,7);
@@ -368,11 +367,11 @@ uint32_t EmonService(struct serviceBlock* _serviceBlock){
 case sendSecure:{
       trace(T_Emon,9);
       if( ! WiFi.isConnected()){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPtoken = HTTPreserve(T_Emon);
       if( ! HTTPtoken){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       if( ! request) {
         request = new asyncHTTPrequest;
@@ -444,13 +443,13 @@ case sendSecure:{
       String auth(EmonUsername);
       auth += ':' + bin2hex(value, 32);
       if(request->debug()){
-        DateTime now = DateTime(localUNIXtime());
+        DateTime now = DateTime(localTime());
         Serial.printf_P(PSTR("time %02d:%02d:%02d, length %d, %d\r\n"), now.hour(),now.minute(),now.second(), reqData.available(), reqUnixtime);
       }
       if( ! request->open("POST", URL.c_str())){
         HTTPrelease(HTTPtoken);
         state = getLastRecord;
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       trace(T_Emon,10);
       request->setReqHeader("Content-Type","aes128cbc");
@@ -475,7 +474,7 @@ case sendSecure:{
             log("EmonService: HTTP response %d, retrying.", request->responseHTTPcode());
         }
         state = getLastRecord;
-        return UNIXtime() + retryCount / 10;
+        return UTCTime() + retryCount / 10;
       }
       trace(T_Emon,11);
       String response = request->responseText();
@@ -488,7 +487,7 @@ case sendSecure:{
           EmonLastPost = reqUnixtime;
         }
         state = getLastRecord;
-        return UNIXtime() + retryCount / 10;
+        return UTCTime() + retryCount / 10;
       }
       trace(T_Emon,11);
       if(retryCount >= 3){

--- a/Firmware/IotaWatt/getConfig.cpp
+++ b/Firmware/IotaWatt/getConfig.cpp
@@ -114,7 +114,9 @@ boolean getConfig(void){
   else {
     EmonStop = true;
   }
+
         // ************************************** configure influxDB **********************************
+
   trace(T_CONFIG,10);
   JsonArray& influxArray = Config[F("influxdb")];
   if(influxArray.success()){
@@ -128,9 +130,28 @@ boolean getConfig(void){
     influxStop = true;
   }
   
-  ConfigFile.close();
+      // ************************************** configure PVoutput **********************************
+
   trace(T_CONFIG,11);
+  JsonArray& PVoutputArray = Config[F("pvoutput")];
+  if(PVoutputArray.success()){
+    char* PVoutputStr = JsonDetail(ConfigFile, PVoutputArray);
+    if(! pvoutput){
+      pvoutput = new PVoutput();
+    }
+    if( ! pvoutput->config(PVoutputStr)){
+      log("PVoutput: Invalid configuration."); 
+    } 
+    delete[] PVoutputStr;
+  }   
+  else {
+   // PVoutputStop = true;
+  }
+  
+  ConfigFile.close();
+  trace(T_CONFIG,12);
   return true;
+
 }                                       // End of getConfig
 
 
@@ -266,10 +287,10 @@ bool configDST(const char* JsonStr){
   for(uint32_t days=1; days<=365*10; days++){
     for(uint32_t min=0; min<(60*24); min++){
       utime+=60;
-      ltime = localTime(utime);
+      ltime = UTC2LocalTimeutime);
       if(ltime - utime != adj){
         adj = ltime - utime;
-        Serial.printf("UTC %s, local %s, offset %f\r\n", dateString(utime).c_str(), dateString(ltime).c_str(), float(adj/3600.0));
+        Serial.printf("UTC %s, local %s, offset %f\r\n", datef(utime).c_str(), datef(ltime).c_str(), float(adj/3600.0));
       }
     }
     yield();

--- a/Firmware/IotaWatt/getConfig.cpp
+++ b/Firmware/IotaWatt/getConfig.cpp
@@ -144,9 +144,9 @@ boolean getConfig(void){
     } 
     delete[] PVoutputStr;
   }   
-  else {
-   // PVoutputStop = true;
-  }
+  else if(pvoutput){
+    pvoutput->end();
+  } 
   
   ConfigFile.close();
   trace(T_CONFIG,12);

--- a/Firmware/IotaWatt/historyLog.cpp
+++ b/Firmware/IotaWatt/historyLog.cpp
@@ -38,7 +38,7 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
         // If iotaLog not open or empty, check back later.
 
       if( ! currLog.isOpen() || (currLog.lastKey() - currLog.firstKey()) < histLog.interval()){
-         return UNIXtime() + histLog.interval(); 
+         return UTCTime() + histLog.interval(); 
       }
 
       log("historyLog: service started."); 
@@ -106,7 +106,7 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
     case logData: {
       trace(T_history,4);   
       if((histLog.lastKey() + histLog.interval()) > currLog.lastKey()){
-        return UNIXtime() + 5;
+        return UTCTime() + 5;
       }
       trace(T_history,5);
       if( ! logRecord){

--- a/Firmware/IotaWatt/historyLog.cpp
+++ b/Firmware/IotaWatt/historyLog.cpp
@@ -38,7 +38,7 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
         // If iotaLog not open or empty, check back later.
 
       if( ! currLog.isOpen() || (currLog.lastKey() - currLog.firstKey()) < histLog.interval()){
-         return UTCTime() + histLog.interval(); 
+         return UTCtime() + histLog.interval(); 
       }
 
       log("historyLog: service started."); 
@@ -106,7 +106,7 @@ uint32_t historyLog(struct serviceBlock* _serviceBlock){
     case logData: {
       trace(T_history,4);   
       if((histLog.lastKey() + histLog.interval()) > currLog.lastKey()){
-        return UTCTime() + 5;
+        return UTCtime() + 5;
       }
       trace(T_history,5);
       if( ! logRecord){

--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -41,14 +41,14 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
   static IotaLogRecord* oldRecord = nullptr;
   static uint32_t lastRequestTime = 0;          // Time of last measurement in last or current request
   static uint32_t lastBufferTime = 0;           // Time of last measurement reqData buffer
-  static uint32_t UnixNextPost = UTCTime();    // Next measurement to be posted
+  static uint32_t UnixNextPost = UTCtime();    // Next measurement to be posted
   static xbuf reqData;                          // Current request buffer
   static uint32_t reqUnixtime = 0;              // First measurement in current reqData buffer
   static int  reqEntries = 0;                   // Number of measurement intervals in current reqData
   static int16_t retryCount = 0;                // HTTP error count
   static asyncHTTPrequest* request = nullptr;   // -> instance of asyncHTTPrequest
-  static uint32_t postFirstTime = UTCTime();   // First measurement in outstanding post request
-  static uint32_t postLastTime = UTCTime();    // Last measurement in outstanding post request
+  static uint32_t postFirstTime = UTCtime();   // First measurement in outstanding post request
+  static uint32_t postLastTime = UTCtime();    // Last measurement in outstanding post request
   static size_t reqDataLimit = 4000;            // transaction yellow light size
   static uint32_t HTTPtoken = 0;                // HTTP resource reservation token
   static Script* script = nullptr;              // current Script
@@ -71,7 +71,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
           // We post from the log, so wait if not available.          
 
       if(!currLog.isOpen()){                  
-        return UTCTime() + 5;
+        return UTCtime() + 5;
       }
       log("influxDB: started, url=%s:%d, db=%s, interval=%d", influxURL, influxPort,
               influxDataBase, influxDBInterval);
@@ -95,11 +95,11 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
 
           // Make sure wifi is connected and there is a resource available.
 
-      if( ! WiFi.isConnected()) return UTCTime() + 1;
+      if( ! WiFi.isConnected()) return UTCtime() + 1;
        
       HTTPtoken = HTTPreserve(T_influx);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
 
           // Create a new request
@@ -192,7 +192,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       }
 
       if(influxLastPost == 0){
-        influxLastPost = UTCTime();
+        influxLastPost = UTCtime();
       }
       influxLastPost -= influxLastPost % influxDBInterval;
       log("influxDB: Start posting at %s", localDateString(influxLastPost + influxDBInterval).c_str());
@@ -268,7 +268,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
           // If not enough entries for bulk-send, come back in one second;
 
       if(((currLog.lastKey() - influxLastPost) / influxDBInterval + reqEntries) < influxBulkSend){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       } 
 
           // If buffer isn't full,
@@ -345,18 +345,18 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
             Script* script = influxOutputs->first();
             reqData.printf_P(PSTR(",%s=%s"), tag->key, influxVarStr(tag->value, script).c_str());
           }
-          reqData.printf_P(PSTR(" value=%d %d\n"), (uint32_t)heapMs / heapMsPeriod, UTCTime());
+          reqData.printf_P(PSTR(" value=%d %d\n"), (uint32_t)heapMs / heapMsPeriod, UTCtime());
           heapMs = 0.0;
           heapMsPeriod = 0;
         }       
       }
-      return (UnixNextPost > UTCTime()) ? UTCTime() + 1 : 1;
+      return (UnixNextPost > UTCtime()) ? UTCtime() + 1 : 1;
     }
 
     case sendPost: {
       trace(T_influx,8);
       if( ! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_influx);
       if( ! HTTPtoken){

--- a/Firmware/IotaWatt/messageLog.cpp
+++ b/Firmware/IotaWatt/messageLog.cpp
@@ -30,9 +30,7 @@ size_t      messageLog::write(const uint8_t byte){
                         this->printf_P("\r\n** Restart **\r\n\n");
                     }
                     if(RTCrunning){
-                        DateTime now = DateTime(localUNIXtime());
-                        this->printf_P(PSTR("%d/%02d/%02d %02d:%02d:%02d "),
-                        now.month(), now.day(), now.year()%100, now.hour(), now.minute(), now.second());
+                        this->printf("%s ", datef(localTime(),"M/DD/YY hh:mm:ss").c_str());
                         if(localTimeDiff == 0){
                             buf[bufPos-1] = 'z';
                             buf[bufPos++] = ' ';

--- a/Firmware/IotaWatt/samplePower.cpp
+++ b/Firmware/IotaWatt/samplePower.cpp
@@ -382,7 +382,7 @@ void samplePower(int channel, int overSample){
     return 1;
   }
   if(abs(samples - (midCrossSamples * 2)) > 10){
-    //DateTime now = DateTime(localUNIXtime());
+    //DateTime now = DateTime(localTime());
     //Serial.printf_P(PSTR("%d/%02d/%02d %02d:%02d:%02d sample imbalance: %d - %d = %d\r\n"), now.month(), now.day(), now.year()%100,
     //now.hour(), now.minute(), now.second(), midCrossSamples, samples-midCrossSamples, abs(samples - (midCrossSamples * 2)));
     return 1;

--- a/Firmware/IotaWatt/statService.cpp
+++ b/Firmware/IotaWatt/statService.cpp
@@ -25,7 +25,7 @@ uint32_t statService(struct serviceBlock* _serviceBlock) {
       statRecord.accum1[i] = 0.0;
       statRecord.accum2[i] = 0.0;
     }
-    return (uint32_t)UNIXtime() + 1;
+    return (uint32_t)UTCTime() + 1;
   }
   
   double elapsedHrs = double((uint32_t)(timeNow - timeThen)) / MS_PER_HOUR;
@@ -56,6 +56,6 @@ uint32_t statService(struct serviceBlock* _serviceBlock) {
   heapMsPeriod += timeNow - timeThen;
   timeThen = timeNow;
   trace(T_stats, 5);
-  return ((uint32_t)UNIXtime() + statServiceInterval);
+  return UTCTime() + statServiceInterval;
 }
 

--- a/Firmware/IotaWatt/statService.cpp
+++ b/Firmware/IotaWatt/statService.cpp
@@ -25,7 +25,7 @@ uint32_t statService(struct serviceBlock* _serviceBlock) {
       statRecord.accum1[i] = 0.0;
       statRecord.accum2[i] = 0.0;
     }
-    return (uint32_t)UTCTime() + 1;
+    return (uint32_t)UTCtime() + 1;
   }
   
   double elapsedHrs = double((uint32_t)(timeNow - timeThen)) / MS_PER_HOUR;
@@ -56,6 +56,6 @@ uint32_t statService(struct serviceBlock* _serviceBlock) {
   heapMsPeriod += timeNow - timeThen;
   timeThen = timeNow;
   trace(T_stats, 5);
-  return UTCTime() + statServiceInterval;
+  return UTCtime() + statServiceInterval;
 }
 

--- a/Firmware/IotaWatt/timeServices.cpp
+++ b/Firmware/IotaWatt/timeServices.cpp
@@ -61,7 +61,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
   trace(T_timeSync, 0);
   if( ! started){
     log("timeSync: service started.");
-    lastNTPupdate = UTCTime();
+    lastNTPupdate = UTCtime();
     started = true; 
   }
  
@@ -77,9 +77,9 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
           // Log if no time update for 24 hours.
 
   trace(T_timeSync, 2);
-  if(UTCTime() - lastNTPupdate > 86400UL){ 
+  if(UTCtime() - lastNTPupdate > 86400UL){ 
     log("timeSync: No time update in last 24 hours.");
-    lastNTPupdate = UTCTime();
+    lastNTPupdate = UTCtime();
   }
 
         // Send an SNTP request.
@@ -100,7 +100,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
     } 
     else {
       trace(T_timeSync, 33);
-      return RTCrunning ? (UTCTime() + 60) : 1;
+      return RTCrunning ? (UTCtime() + 60) : 1;
     }
   }
   
@@ -112,7 +112,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
     if(millis() - sendMillis > (RTCrunning ? 3000 : 10000)){
       trace(T_timeSync, 42);
       udp.stop();
-      return RTCrunning ? (UTCTime() + 60) : 1;
+      return RTCrunning ? (UTCtime() + 60) : 1;
     }
   }
 
@@ -133,7 +133,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
 
   trace(T_timeSync, 6);
   if(packetSize < sizeof(ntpPacket) || recvMillis - sendMillis > (RTCrunning ? 3000 : 10000)){
-    return RTCrunning ? (UTCTime() + 60) : 1;
+    return RTCrunning ? (UTCtime() + 60) : 1;
   }
 
         // Check for Kiss-o'-Death packet
@@ -142,17 +142,17 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
   if(packet.stratum == 0){
     log("timesync: Kiss-o'-Death, code %c%c%c%c, ip: %s", 
     packet.referenceID[0], packet.referenceID[1], packet.referenceID[2], packet.referenceID[3], timeServerIP.toString().c_str());
-    return UTCTime() + 15;
+    return UTCtime() + 15;
   } 
 
   trace(T_timeSync, 8);
   if(packet.origin_ts_sec != origin_sec || packet.origin_ts_frac != origin_frac){
     trace(T_timeSync, 81);
-    return RTCrunning ? (UTCTime() + 60) : 1;
+    return RTCrunning ? (UTCtime() + 60) : 1;
   }
   if(packet.trans_ts_sec < NTP2018 || packet.trans_ts_sec > NTP2028){
     trace(T_timeSync, 82);
-    return RTCrunning ? (UTCTime() + 60) : 1;
+    return RTCrunning ? (UTCtime() + 60) : 1;
   }
 
         // compute time as NTP transmit time + 1/2 transaction duration.
@@ -170,13 +170,13 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
     trace(T_timeSync, 91);
     prevDiff = presDiff; 
     prevIP = timeServerIP;
-    return RTCrunning ? (UTCTime() + 60) : 1;
+    return RTCrunning ? (UTCtime() + 60) : 1;
   }
   if(prevDiff){
     trace(T_timeSync, 92);
     if(prevIP == timeServerIP){
       trace(T_timeSync, 93);
-      return RTCrunning ? (UTCTime() + 60) : 1;
+      return RTCrunning ? (UTCtime() + 60) : 1;
     }
     //log("IPs: %s, %s, prevDiff: %d", prevIP.toString().c_str(), timeServerIP.toString().c_str(), prevDiff);
     //log("packet sec: %u, frac: %u",packet.trans_ts_sec, packet.trans_ts_frac);
@@ -189,14 +189,14 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
   trace(T_timeSync, 10);
   timeRefNTP = current_ts_sec - 1;
   timeRefMs = recvMillis - 1000 - current_ts_frac;
-  lastNTPupdate = UTCTime();
+  lastNTPupdate = UTCtime();
  
         // If RTC not running, set it.
 
   if( ! RTCrunning) {
     trace(T_timeSync, 11);
-    programStartTime = UTCTime();
-    rtc.adjust(UTCTime());
+    programStartTime = UTCtime();
+    rtc.adjust(UTCtime());
     RTCrunning = true;
     log("timeSync: RTC initalized to NTP time");
     SdFile::dateTimeCallback(dateTime);
@@ -207,7 +207,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
 
   else {
     trace(T_timeSync, 12);
-    int32_t timeDiff = UTCTime() - rtc.now().unixtime();
+    int32_t timeDiff = UTCtime() - rtc.now().unixtime();
     if(timeDiff < 0){
       timeDiff += 1;
     } else if(timeDiff > 0){
@@ -225,7 +225,7 @@ uint32_t timeSync(struct serviceBlock* _serviceBlock) {
           // Go back to sleep.
 
   trace(T_timeSync, 14);
-  return UTCTime() + timeSynchInterval;    
+  return UTCtime() + timeSynchInterval;    
 }
 
 //  This can be a little mind-bogling. The ESP stores words in little-endian format,
@@ -269,12 +269,12 @@ uint32_t NTPtime() {
   return timeRefNTP + ((uint32_t)(millis() - timeRefMs)) / 1000;
  }
   
-uint32_t UTCTime() {
+uint32_t UTCtime() {
   return timeRefNTP + ((uint32_t)(millis() - timeRefMs)) / 1000 - SEVENTY_YEAR_SECONDS;
  }
 
 uint32_t localTime() {
-  return UTC2Local(UTCTime());
+  return UTC2Local(UTCtime());
 } 
  
 uint32_t millisAtUTCTime(uint32_t UnixTime){                  

--- a/Firmware/IotaWatt/timeServices.h
+++ b/Firmware/IotaWatt/timeServices.h
@@ -22,7 +22,7 @@ struct tzRule {                 // Defines a daylight saving period and adjustme
 };  
 
 uint32_t  NTPtime();
-uint32_t  UTCTime();
+uint32_t  UTCtime();
 uint32_t  localTime();
 uint32_t  millisAtUTCTime(uint32_t);
 void      dateTime(uint16_t* date, uint16_t* time);

--- a/Firmware/IotaWatt/timeServices.h
+++ b/Firmware/IotaWatt/timeServices.h
@@ -22,12 +22,13 @@ struct tzRule {                 // Defines a daylight saving period and adjustme
 };  
 
 uint32_t  NTPtime();
-uint32_t  UNIXtime();
-uint32_t  localUNIXtime();
-uint32_t  MillisAtUNIXtime(uint32_t);
+uint32_t  UTCTime();
+uint32_t  localTime();
+uint32_t  millisAtUTCTime(uint32_t);
 void      dateTime(uint16_t* date, uint16_t* time);
 uint32_t  littleEndian(uint32_t);
-uint32_t localTime();
-uint32_t localTime(uint32_t UTCtime);
-bool     testRule(uint32_t standardTime, dateTimeRule);
+uint32_t  localTime();
+uint32_t  UTC2Local(uint32_t UTCtime);
+uint32_t  local2UTC(uint32_t localTime);
+bool      testRule(uint32_t standardTime, dateTimeRule);
 

--- a/Firmware/IotaWatt/updater.cpp
+++ b/Firmware/IotaWatt/updater.cpp
@@ -20,7 +20,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
   static uint32_t HTTPtoken = 0;
 
   if( ! WiFi.isConnected()){
-    return UNIXtime() + 1;
+    return UTCTime() + 1;
   }
 
   switch(state){
@@ -44,21 +44,21 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
           return 1;
         }
       }
-      else if (strcmp(_updateClass, "NONE") != 0 && UNIXtime() - lastVersionCheck > updaterServiceInterval){
-        lastVersionCheck = UNIXtime();
+      else if (strcmp(_updateClass, "NONE") != 0 && UTCTime() - lastVersionCheck > updaterServiceInterval){
+        lastVersionCheck = UTCTime();
         state = getVersion;
         return 1;
       }
-      return UNIXtime() + 7;
+      return UTCTime() + 7;
     }
 
     case getVersion: {
       if( ! WiFi.isConnected()){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPtoken = HTTPreserve(T_UPDATE);
       if( ! HTTPtoken){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -85,7 +85,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
 
     case waitVersion: {
       if(request->readyState() != 4){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPrelease(HTTPtoken);;
       if(request->responseHTTPcode() != 200 || request->available() != 8){
@@ -99,9 +99,9 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
         state = getVersion;
         state = checkAutoUpdate;
         if(responseCode == 403){
-          lastVersionCheck = UNIXtime();
+          lastVersionCheck = UTCTime();
         }
-        return UNIXtime() + 11 ;
+        return UTCTime() + 11 ;
       }
       checkResponse = 0;
       updateVersion = request->responseText();
@@ -142,11 +142,11 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
       
     case download: {  
       if( ! WiFi.isConnected()){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       HTTPtoken = HTTPreserve(T_UPDATE, true);
       if( ! HTTPtoken){
-        return UNIXtime() + 1;
+        return UTCTime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -205,7 +205,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
       state = checkAutoUpdate;
     }
   }
-  return UNIXtime() + 1;
+  return UTCTime() + 1;
 }
 
 /**************************************************************************************************

--- a/Firmware/IotaWatt/updater.cpp
+++ b/Firmware/IotaWatt/updater.cpp
@@ -20,7 +20,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
   static uint32_t HTTPtoken = 0;
 
   if( ! WiFi.isConnected()){
-    return UTCTime() + 1;
+    return UTCtime() + 1;
   }
 
   switch(state){
@@ -44,21 +44,21 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
           return 1;
         }
       }
-      else if (strcmp(_updateClass, "NONE") != 0 && UTCTime() - lastVersionCheck > updaterServiceInterval){
-        lastVersionCheck = UTCTime();
+      else if (strcmp(_updateClass, "NONE") != 0 && UTCtime() - lastVersionCheck > updaterServiceInterval){
+        lastVersionCheck = UTCtime();
         state = getVersion;
         return 1;
       }
-      return UTCTime() + 7;
+      return UTCtime() + 7;
     }
 
     case getVersion: {
       if( ! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_UPDATE);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -85,7 +85,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
 
     case waitVersion: {
       if(request->readyState() != 4){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPrelease(HTTPtoken);;
       if(request->responseHTTPcode() != 200 || request->available() != 8){
@@ -99,9 +99,9 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
         state = getVersion;
         state = checkAutoUpdate;
         if(responseCode == 403){
-          lastVersionCheck = UTCTime();
+          lastVersionCheck = UTCtime();
         }
-        return UTCTime() + 11 ;
+        return UTCtime() + 11 ;
       }
       checkResponse = 0;
       updateVersion = request->responseText();
@@ -142,11 +142,11 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
       
     case download: {  
       if( ! WiFi.isConnected()){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       HTTPtoken = HTTPreserve(T_UPDATE, true);
       if( ! HTTPtoken){
-        return UTCTime() + 1;
+        return UTCtime() + 1;
       }
       if( ! request){
         request = new asyncHTTPrequest;
@@ -205,7 +205,7 @@ uint32_t updater(struct serviceBlock* _serviceBlock) {
       state = checkAutoUpdate;
     }
   }
-  return UTCTime() + 1;
+  return UTCtime() + 1;
 }
 
 /**************************************************************************************************

--- a/Firmware/IotaWatt/utilities.cpp
+++ b/Firmware/IotaWatt/utilities.cpp
@@ -254,9 +254,9 @@ uint32_t Unixtime(int year, uint8_t month, uint8_t day, uint8_t hour, uint8_t mi
  *     datef(unixtime, format) Generate formatted date/time string.                                                               *  
  * ************************************************************************************************/
 String datef(uint32_t unixtime, const char* format){
-    uint16_t month2date[] = {0,31,59,90,120,151,181,212,243,273,304,334,365};
-    uint16_t month2leapdate[] = {0,31,60,91,121,152,182,213,244,274,305,335,366};
-    char formatChar[] = {"YMDhms"};
+    const uint16_t month2date[] = {0,31,59,90,120,151,181,212,243,273,304,334,365};
+    const uint16_t month2leapdate[] = {0,31,60,91,121,152,182,213,244,274,305,335,366};
+    const char formatChar[] = {"YMDhms"};
     int value[6];                                           // YMDHMS
     uint32_t daytime = unixtime % 86400;                    // Get time of day
     value[3] = daytime / 3600;                              // Extract hour
@@ -270,12 +270,12 @@ String datef(uint32_t unixtime, const char* format){
     if(unixtime < 1095){                                    // Ends in one of first three non-leapyears
         value[0] += unixtime / 365;                             // Add whole years
         unixtime = unixtime % 365;                          // Days in last year (-1)
-        while(unixtime > month2date[++month]);              // Lookup month
+        while(unixtime >= month2date[++month]);              // Lookup month
         value[2] = unixtime - month2date[month-1] + 1;      // Compute residual days
     } else {                                                // Ends in leap year
         value[0] += 3;                                      // Count three good years    
         unixtime -= 1095;                                   // Days in last year (-1)    
-        while(unixtime > month2leapdate[++month]);          // Lookup month in leapyear
+        while(unixtime >= month2leapdate[++month]);          // Lookup month in leapyear
         value[2] = unixtime - month2leapdate[month-1] + 1;  // Compute residual days
     }
     value[1] = month;

--- a/Firmware/IotaWatt/utilities.cpp
+++ b/Firmware/IotaWatt/utilities.cpp
@@ -306,7 +306,7 @@ String datef(uint32_t unixtime, const char* format){
         }
     }
     *out = 0;
-    String result = str;
+    String result(str);
     delete[] str;
     return result;
 }
@@ -323,7 +323,7 @@ uint32_t YYYYMMDD2Unixtime(const char* YYYYMMDD){
     return 0; 
 }
 
-int32_t HHMM2daytime(const char* HHMMSS, const char* format){
+int32_t HHMMSS2daytime(const char* HHMMSS, const char* format){
     int hour(0), minute(0), second(0);
     if(sscanf(HHMMSS, format, &hour, &minute, &second)){
         return hour * 3600 + minute * 60 + second;

--- a/Firmware/IotaWatt/utilities.h
+++ b/Firmware/IotaWatt/utilities.h
@@ -17,14 +17,16 @@ String formatHex(uint32_t data);                    // Convert the input to a St
 String bin2hex(const uint8_t* in, size_t len);
 void   hex2bin(uint8_t* out, const char* in, size_t len); 
 
-void base64encode(xbuf* buf);                       // Convert the contents of an xbuf to base64
+void   base64encode(xbuf* buf);                     // Convert the contents of an xbuf to base64
 String base64encode(const uint8_t* in, size_t len); // Convert the input buffer to a base64 String
 
-String  JsonSummary(File file, int depth);          // Read a json file and return a summary Json string              
+String JsonSummary(File file, int depth);           // Read a json file and return a summary Json string              
 char*  JsonDetail(File file, JsonArray& locator);   // Read and compress a detail segment of a json file
 
 String localDateString(uint32_t UNIXtime);          // Convert unixtime to a local data/time string
-String dateString(uint32_t UNIXtime);               // Convert unixtime to a data/time string
-String timeString(int value);                       // Convert time to String(HH:MM:SS)
+uint32_t Unixtime(int year, uint8_t month, uint8_t day, uint8_t hour=0, uint8_t minute=0, uint8_t second=0); // Convert YMDhms to unixtime
+uint32_t YYYYMMDD2Unixtime(const char* YYYYMMDD);   // Convert character string YYYYMMDD to unixtime
+String datef(uint32_t unixtime, const char* format = "MM/DD/YY hh:mm:ss");
+int32_t HHMMSS2daytime(const char* HHMMSS, const char* format = "%2d:%2d:%2d");
 
 void hashFile(uint8_t* sha, File file);             // Get SHA256 hash of a file    

--- a/Firmware/IotaWatt/webServer.cpp
+++ b/Firmware/IotaWatt/webServer.cpp
@@ -464,7 +464,7 @@ void handleStatus(){
     trace(T_WEB,14);
     stats.set(F("chanrate"),cycleSampleRate);
     trace(T_WEB,14);
-    stats.set(F("runseconds"), UTCTime()-programStartTime);
+    stats.set(F("runseconds"), UTCtime()-programStartTime);
     trace(T_WEB,14);
     stats.set(F("stack"),ESP.getFreeHeap());
     trace(T_WEB,14);

--- a/Firmware/IotaWatt/webServer.cpp
+++ b/Firmware/IotaWatt/webServer.cpp
@@ -464,7 +464,7 @@ void handleStatus(){
     trace(T_WEB,14);
     stats.set(F("chanrate"),cycleSampleRate);
     trace(T_WEB,14);
-    stats.set(F("runseconds"), UNIXtime()-programStartTime);
+    stats.set(F("runseconds"), UTCTime()-programStartTime);
     trace(T_WEB,14);
     stats.set(F("stack"),ESP.getFreeHeap());
     trace(T_WEB,14);
@@ -534,6 +534,17 @@ void handleStatus(){
     emon.set(F("running"),EmonStarted);
     emon.set(F("lastpost"),EmonLastPost);  
     root["emon"] = emon;
+  }
+
+  if(server.hasArg(F("pvoutput"))){
+    trace(T_WEB,23);
+    JsonObject& status = jsonBuffer.createObject();
+    if(!pvoutput){
+      status.set(F("state"),"stopped");
+    } else {
+      pvoutput->getStatusJson(status);
+    }
+    root["pvoutput"] = status;
   }
 
   if(server.hasArg(F("datalogs"))){


### PR DESCRIPTION
Don't use WiFi Manager except after power cycle.  This should eliminate problem with blocking for WiFiManager timeout after program restarts and also increase security as wifi configuration is only exposed in AP after power cycle.