### PR TITLE
Add more options for time intervals, more like Grafana

### DIFF
--- a/SD/graph.htm
+++ b/SD/graph.htm
@@ -80,7 +80,7 @@
 
     <div id="page-content-wrapper" style="max-width:1280px">
         
-        <h3>Data viewer</h3> 
+        <h3 id="heading">Data viewer</h3> 
 
         <div id="error" style="display:none"></div>
 
@@ -206,7 +206,7 @@
     </div>
 </div>
 
-<!- copy of https://emoncms.org/Modules/graph/vis.helper.js -->
+<!-- copy of https://emoncms.org/Modules/graph/vis.helper.js -->
 <script>
   var view =
 {
@@ -399,13 +399,31 @@ function parseTimepickerTime(timestr){
 
     return new Date(date[2],date[1]-1,date[0],time[0],time[1],time[2],0).getTime() / 1000;
 }
+
+function readFile(path, responseHandler){
+  var xmlHttp = new XMLHttpRequest();
+  xmlHttp.onreadystatechange = function() {
+    if (this.readyState == 4 && this.status == 200) {
+      if(this.getResponseHeader("X-configSHA256") !== null){
+        configSHA256 = this.getResponseHeader("X-configSHA256");
+      }
+      responseHandler(this.responseText);
+    }
+  };
+  xmlHttp.open("GET", path, true);
+  xmlHttp.send();
+}
+
+function EbyId(id) {return document.getElementById(id)};
+
 </script>
 
 <script language="javascript" type="text/javascript" src="graph.js"></script>
 
 <script>
     var path = "http://" + location.host; // + "/";
-	  var getbackup = false;
+	var getbackup = false;
+    var configFileURL = "config.txt";
     
     sidebar_resize();
     graph_init_editor();
@@ -427,6 +445,14 @@ function parseTimepickerTime(timestr){
     view.end = now;
     view.calc_interval();
     
+    if (document.domain != "iotawatt.com") {
+        readFile(configFileURL, function(response){
+        var config = JSON.parse(response);
+        if (config.device.name !== null) {
+            EbyId("heading").innerHTML = config.device.name + " Data Viewer";
+        }
+        });
+    }
     
     graph_reload();
     

--- a/SD/graph.htm
+++ b/SD/graph.htm
@@ -86,24 +86,25 @@
 
         <div id="navigation" style="padding-bottom:5px;">
             <button class="btn" id="sidebar-open"><i class="icon-list"></i></button>
-            <select  class="btn" name="options">
-                <option class='sel graph_time' time='60'>Last 1 min</option>
-                <option class='sel graph_time' time='180'>Last 3 min</option>
-                <option class='sel graph_time' time='300'>Last 5 min</option>
-                <option class='sel graph_time' time='600'>Last 10 min</option>
-                <option class='sel graph_time' time='900'>Last 15 min</option>
-                <option class='sel graph_time' time='1800'>Last 30 min</option>
-                <option class='sel graph_time' time='3600' selected>Last 1 hour</option>
-                <option class='sel graph_time' time='10800'>Last 3 hours</option>
-                <option class='sel graph_time' time='21600'>Last 6 hours</option>
-                <option class='sel graph_time' time='43200'>Last 12 hours</option>
-                <option class='sel graph_time' time='86400'>Last 1 day</option>
-                <option class='sel graph_time' time='259200'>Last 3 days</option>
-                <option class='sel graph_time' time='604800'>Last 7 days</option>
-                <option class='sel graph_time' time='2592000'>Last 30 days</option>
-                <option class='sel graph_time' time='7776000'>Last 90 days</option>
-                <option class='sel graph_time' time='15552000'>Last 180 days</option>
-                <option class='sel graph_time' time='31536000'>Last 365 days</option>
+            <select id="select-time" class="btn sel graph_time" name="options" style="width: 150px">
+                    <option value="1" disabled>Select period</option>
+                    <option value='60'>Last 1 min</option>
+                    <option value='180'>Last 3 min</option>
+                    <option value='300'>Last 5 min</option>
+                    <option value='600'>Last 10 min</option>
+                    <option value='900'>Last 15 min</option>
+                    <option value='1800'>Last 30 min</option>
+                    <option value='3600' selected>Last 1 hour</option>
+                    <option value='10800'>Last 3 hours</option>
+                    <option value='21600'>Last 6 hours</option>
+                    <option value='43200'>Last 12 hours</option>
+                    <option value='86400'>Last 1 day</option>
+                    <option value='259200'>Last 3 days</option>
+                    <option value='604800'>Last 7 days</option>
+                    <option value='2592000'>Last 30 days</option>
+                    <option value='7776000'>Last 90 days</option>
+                    <option value='15552000'>Last 180 days</option>
+                    <option value='31536000'>Last 365 days</option>
             </select>
             <button id='graph_zoomin' class='btn'>+</button>
             <button id='graph_zoomout' class='btn'>-</button>
@@ -213,6 +214,11 @@
   end:0,
   fixinterval:false,
 
+  'clearTimeSelect':function ()
+  {
+    $("#select-time").val(1);
+  },
+
   'zoomout':function ()
   {
     var time_window = this.end - this.start;
@@ -221,6 +227,7 @@
     this.start = middle - (time_window/2);
     this.end = middle + (time_window/2);
     this.calc_interval();
+    this.clearTimeSelect();
   },
 
   'zoomin':function ()
@@ -231,6 +238,7 @@
     this.start = middle - (time_window/2);
     this.end = middle + (time_window/2);
     this.calc_interval();
+    this.clearTimeSelect();
   },
 
   'panright':function ()

--- a/SD/graph.htm
+++ b/SD/graph.htm
@@ -86,21 +86,25 @@
 
         <div id="navigation" style="padding-bottom:5px;">
             <button class="btn" id="sidebar-open"><i class="icon-list"></i></button>
-            <button class='btn graph_time' type='button' time='60'>1m</button>
-            <button class='btn graph_time' type='button' time='180'>3m</button>
-            <button class='btn graph_time' type='button' time='300'>5m</button>
-            <button class='btn graph_time' type='button' time='600'>10m</button>
-            <button class='btn graph_time' type='button' time='900'>15m</button>
-            <button class='btn graph_time' type='button' time='1800'>30m</button>
-            <button class='btn graph_time' type='button' time='3600'>1H</button>
-            <button class='btn graph_time' type='button' time='10800'>3H</button>
-            <button class='btn graph_time' type='button' time='21600'>6H</button>
-            <button class='btn graph_time' type='button' time='43200'>12H</button>
-            <button class='btn graph_time' type='button' time='86400'>1D</button>
-            <button class='btn graph_time' type='button' time='604800'>7D</button>
-            <button class='btn graph_time' type='button' time='2592000'>30D</button>
-            <button class='btn graph_time' type='button' time='7776000'>90D</button>
-            <button class='btn graph_time' type='button' time='31536000'>365D</button>
+            <select  class="btn" name="options">
+                <option class='sel graph_time' time='60'>Last 1 min</option>
+                <option class='sel graph_time' time='180'>Last 3 min</option>
+                <option class='sel graph_time' time='300'>Last 5 min</option>
+                <option class='sel graph_time' time='600'>Last 10 min</option>
+                <option class='sel graph_time' time='900'>Last 15 min</option>
+                <option class='sel graph_time' time='1800'>Last 30 min</option>
+                <option class='sel graph_time' time='3600' selected>Last 1 hour</option>
+                <option class='sel graph_time' time='10800'>Last 3 hours</option>
+                <option class='sel graph_time' time='21600'>Last 6 hours</option>
+                <option class='sel graph_time' time='43200'>Last 12 hours</option>
+                <option class='sel graph_time' time='86400'>Last 1 day</option>
+                <option class='sel graph_time' time='259200'>Last 3 days</option>
+                <option class='sel graph_time' time='604800'>Last 7 days</option>
+                <option class='sel graph_time' time='2592000'>Last 30 days</option>
+                <option class='sel graph_time' time='7776000'>Last 90 days</option>
+                <option class='sel graph_time' time='15552000'>Last 180 days</option>
+                <option class='sel graph_time' time='31536000'>Last 365 days</option>
+            </select>
             <button id='graph_zoomin' class='btn'>+</button>
             <button id='graph_zoomout' class='btn'>-</button>
             <button id='graph_left' class='btn'><</button>

--- a/SD/graph.htm
+++ b/SD/graph.htm
@@ -86,10 +86,21 @@
 
         <div id="navigation" style="padding-bottom:5px;">
             <button class="btn" id="sidebar-open"><i class="icon-list"></i></button>
-            <button class='btn graph_time' type='button' time='1'>D</button>
-            <button class='btn graph_time' type='button' time='7'>W</button>
-            <button class='btn graph_time' type='button' time='30'>M</button>
-            <button class='btn graph_time' type='button' time='365'>Y</button>
+            <button class='btn graph_time' type='button' time='60'>1m</button>
+            <button class='btn graph_time' type='button' time='180'>3m</button>
+            <button class='btn graph_time' type='button' time='300'>5m</button>
+            <button class='btn graph_time' type='button' time='600'>10m</button>
+            <button class='btn graph_time' type='button' time='900'>15m</button>
+            <button class='btn graph_time' type='button' time='1800'>30m</button>
+            <button class='btn graph_time' type='button' time='3600'>1H</button>
+            <button class='btn graph_time' type='button' time='10800'>3H</button>
+            <button class='btn graph_time' type='button' time='21600'>6H</button>
+            <button class='btn graph_time' type='button' time='43200'>12H</button>
+            <button class='btn graph_time' type='button' time='86400'>1D</button>
+            <button class='btn graph_time' type='button' time='604800'>7D</button>
+            <button class='btn graph_time' type='button' time='2592000'>30D</button>
+            <button class='btn graph_time' type='button' time='7776000'>90D</button>
+            <button class='btn graph_time' type='button' time='31536000'>365D</button>
             <button id='graph_zoomin' class='btn'>+</button>
             <button id='graph_zoomout' class='btn'>-</button>
             <button id='graph_left' class='btn'><</button>
@@ -238,7 +249,8 @@
 
   'timewindow':function(time)
   {
-    this.start = ((new Date()).getTime())-(3600000*24*time);	//Get start time
+    //time is now in seconds
+    this.start = ((new Date()).getTime())-(1000*time);	//Get start time
     this.end = (new Date()).getTime();	//Get end time
     this.calc_interval();
   },
@@ -397,7 +409,7 @@ function parseTimepickerTime(timestr){
     load_feed_selector();
     graph_resize();
     
-    var timeWindow = 3600000*24.0;
+    var timeWindow = 3600000*1; //default to 1 hour
     var now = Math.round(+new Date * 0.001)*1000;
     view.start = now - timeWindow;
     view.end = now;

--- a/SD/graph.js
+++ b/SD/graph.js
@@ -578,8 +578,8 @@ function graph_draw()
         if (showtag) label += feedlist[z].tag+": ";
         label += feedlist[z].name;
         if (yaxisUsed == 3) {
-            if (feedlist[z].yaxis == 1) {label += " &larr;"};
-            if (feedlist[z].yaxis == 2) {label += " &rarr;"};    
+            if (feedlist[z].yaxis == 1) {label += " &#10229;"}; // Long Left Arrow
+            if (feedlist[z].yaxis == 2) {label += " &#10230;"}; // Long Right Arrow 
         }
 
         var plot = {label:label, data:data, yaxis:feedlist[z].yaxis, color: feedlist[z].color};

--- a/SD/graph.js
+++ b/SD/graph.js
@@ -34,9 +34,10 @@ $("#graph_zoomout").click(function () {floatingtime=0; view.zoomout(); graph_rel
 $("#graph_zoomin").click(function () {floatingtime=0; view.zoomin(); graph_reload();});
 $('#graph_right').click(function () {floatingtime=0; view.panright(); graph_reload();});
 $('#graph_left').click(function () {floatingtime=0; view.panleft(); graph_reload();});
-$('.graph_time').click(function () {
+$('.graph_time').change(function () {
     floatingtime=1; 
-    view.timewindow($(this).attr("time")); 
+    view.timewindow($(this).val());
+    $(this).blur();
     graph_reload();
 });
 

--- a/SD/graph.js
+++ b/SD/graph.js
@@ -556,6 +556,11 @@ function graph_draw()
     if (!embed) $("#window-info").html("<b>Window:</b> "+printdate(view.start)+" > "+printdate(view.end)+", <b>Length:</b> "+hours+"h"+mins+" ("+time_in_window+" seconds)");
     
     plotdata = [];
+    var yaxisUsed = 0;
+    for (var z in feedlist){
+        yaxisUsed |= feedlist[z].yaxis;
+    }
+
     for (var z in feedlist) {
         
         var data = feedlist[z].data;
@@ -572,6 +577,11 @@ function graph_draw()
         var label = "";
         if (showtag) label += feedlist[z].tag+": ";
         label += feedlist[z].name;
+        if (yaxisUsed == 3) {
+            if (feedlist[z].yaxis == 1) {label += " &larr;"};
+            if (feedlist[z].yaxis == 2) {label += " &rarr;"};    
+        }
+
         var plot = {label:label, data:data, yaxis:feedlist[z].yaxis, color: feedlist[z].color};
         
         if (feedlist[z].plottype=='lines') plot.lines = { show: true, fill: feedlist[z].fill };
@@ -865,6 +875,7 @@ $("#graph-select").change(function() {
     
     load_feed_selector();
 
+    view.clearTimeSelect();
     graph_reload();
 });
 

--- a/SD/graph.js
+++ b/SD/graph.js
@@ -51,6 +51,7 @@ $('#placeholder').bind("plotselected", function (event, ranges)
     view.start = ranges.xaxis.from;
     view.end = ranges.xaxis.to;
     view.calc_interval();
+    view.clearTimeSelect();
     
     graph_reload();
 });

--- a/SD/index.htm
+++ b/SD/index.htm
@@ -2588,6 +2588,7 @@ function getConfig(callback){
     config = JSON.parse(response);
     checkConfig();
     document.title = config.device.name;
+    EbyId("heading").innerHTML = config.device.name + " Power Monitor";
     if(callback !== undefined) callback();
     });
     EbyId("mainMenu").style.display = "block";
@@ -2664,7 +2665,7 @@ function setup(){
   if(document.domain == "iotawatt.com"){
     demo = true;
     EbyId("heading").innerHTML += " Demo Mode";
-  } 
+  }
   resetDisplay();
 }
 


### PR DESCRIPTION
I always hated that emoncms used 1 week as the starting window.  I liked that you used 1 day, but I like Grafana's way of doing it better.  This makes the graph closer to the ease that Grafana has for selecting time periods.  It is still better, but this was a quick and simple change.  Tested on Edge and Android Chrome and looks good.  Should be fine on other browsers, the layout flows nicely, but is still less refined than what you get with Grafana (but making that better would be a huge change ;-)).