### PR TITLE
Update graph.htm to be protocol independent

### DIFF
--- a/SD/graph.htm
+++ b/SD/graph.htm
@@ -431,8 +431,8 @@ function EbyId(id) {return document.getElementById(id)};
 <script language="javascript" type="text/javascript" src="graph.js"></script>
 
 <script>
-    var path = "http://" + location.host; // + "/";
-	var getbackup = false;
+    var path = location.protocol + "//" + location.host; // + "/";
+    var getbackup = false;
     var configFileURL = "config.txt";
     
     sidebar_resize();


### PR DESCRIPTION
This change should allow nginx with HTTPS infront of iotawatt to work properly. Currently we get mixed content errors for files fetched based on this path configuration.