### PR TITLE
Reduce heap requirement to process config

### DIFF
--- a/Firmware/IotaWatt/IotaWatt.h
+++ b/Firmware/IotaWatt/IotaWatt.h
@@ -220,6 +220,7 @@ extern uint8_t  deviceMajorVersion;           // Major version of hardware
 extern uint8_t  deviceMinorVersion;           // Minor version of hardware 
 extern float    VrefVolts;                    // Voltage reference shunt value used to calibrate
                                               // the ADCs. (can be specified in config.device.refvolts)
+extern int16_t* masterPhaseArray;             // Single array containing all individual phase shift arrays    
 #define Vadj_3 13                             // Voltage channel attenuation ratio
 
       // ****************************************************************************

--- a/Firmware/IotaWatt/common.cpp
+++ b/Firmware/IotaWatt/common.cpp
@@ -134,19 +134,20 @@ traceUnion traceEntry;
        * We try to run everything else during the half-wave intervals between power sampling.  
        **************************************************************************************************/
        
-uint32_t lastCrossMs = 0;             // Timestamp at last zero crossing (ms) (set in samplePower)
-uint32_t nextCrossMs = 0;             // Time just before next zero crossing (ms) (computed in Loop)
+uint32_t lastCrossMs = 0;                 // Timestamp at last zero crossing (ms) (set in samplePower)
+uint32_t nextCrossMs = 0;                 // Time just before next zero crossing (ms) (computed in Loop)
 
       // Various queues and lists of resources.
 
-serviceBlock* serviceQueue;           // Head of active services list in order of dispatch time.       
+serviceBlock* serviceQueue;               // Head of active services list in order of dispatch time.       
 IotaInputChannel* *inputChannel = nullptr; // -->s to incidences of input channels (maxInputs entries) 
-uint8_t maxInputs = 0;                // channel limit based on configured hardware (set in Config)      
-ScriptSet* outputs;                   // -> scriptSet for output channels
+uint8_t     maxInputs = 0;                // channel limit based on configured hardware (set in Config)
+int16_t*    masterPhaseArray = nullptr;   // Single array containing all individual phase shift arrays          
+ScriptSet*  outputs;                      // -> scriptSet for output channels
 
-uint8_t  deviceMajorVersion = 4;      // Default to 4.8
-uint8_t  deviceMinorVersion = 8;                 
-float    VrefVolts = 2.5;             // Voltage reference shunt value used to calibrate
+uint8_t     deviceMajorVersion = 4;       // Default to 4.8
+uint8_t     deviceMinorVersion = 8;                 
+float       VrefVolts = 2.5;              // Voltage reference shunt value used to calibrate
 
       // ****************************************************************************
       // statService maintains current averages of the channel values

--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -111,7 +111,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       request->setTimeout(5);
       request->setDebug(false);
       {
-        char* URL = new char[100];
+        char URL[100];
         sprintf_P(URL, PSTR("%s/query"),influxURL->build().c_str());
         if( ! request->open("POST", URL)){
           HTTPrelease(HTTPtoken);
@@ -167,15 +167,16 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       }
       String response = request->responseText(); 
       int HTTPcode = request->responseHTTPcode();
-      delete request;
-      request = nullptr;
+      
       if(HTTPcode < 0){
-        if(retryCount++ == 20){
+        if(retryCount++ == 10){
           log("influxDB: last entry query failed: %d, retrying.", HTTPcode);
         }
         state = queryLast;
-        return UTCtime() + (retryCount < 20 ? 1 : retryCount / 10);
+        return UTCtime() + (retryCount <= 10 ? 2 : 10);
       }
+      delete request;
+      request = nullptr;
       retryCount = 0;
       trace(T_influx,5);
 

--- a/Firmware/IotaWatt/iotaInputChannel.cpp
+++ b/Firmware/IotaWatt/iotaInputChannel.cpp
@@ -9,9 +9,7 @@ void IotaInputChannel::reset(){
 	_burden = 0;
     _calibration = 0;
     _phase = 0;
-    delete[] _p50;
     _p50 = nullptr;
-    delete[] _p60;
     _p60 = nullptr;
 	_active = false;
     _reversed = false;


### PR DESCRIPTION
The process to set dynamic phase correction arrays for inputs was consuming an astonishing 16K when processing the congfig file.  Not a problem at startup but done each time a configuration change is made while running.  Was causing unexplained exceptions due to heap allocation failure.  New process does not Json parse table file, but works directly on file.  Extra savings on using same arrays for like models.