### PR TITLE
Graph2 path debugging variable trailing slash fix

### DIFF
--- a/SD/graph2.js
+++ b/SD/graph2.js
@@ -14,7 +14,8 @@ var refreshTimer;
 var refresh = false;
 var selectedunitcolor = "#00a1d8"; // Color to be used for selected unit
 
-var path = ""; //https://" + location.host; // + "/";     // used to call home
+var path = ""; //https://" + location.host; // used to call home
+// path = "http://iotawatt.local"; // Temp: Local development (Can use the following Chrome extension to allow remote Ajax calls: https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf?hl=en)
 
 //*********************************************************************************************
 //                      Predefined reporting periods that can be selected
@@ -794,7 +795,7 @@ function query() {
 
   var request =
     path +
-    "query?format=json&header=yes&resolution=high&missing=null" +
+    "/query?format=json&header=yes&resolution=high&missing=null" +
     "&begin=" +
     begin +
     "&end=" +


### PR DESCRIPTION
Fixed a bug within graph2 where the `path` debugging variable could not be used due to inconsistent trailing slash expectations in the ajax calls.

E.g.
- [This query expects that the `path` variable has a trailing slash](https://github.com/boblemaire/IoTaWatt/blob/d8eba9239988acc4c459ff88abe5550d8c69f740/SD/graph2.js#L795-L802)
- [This query expects that the `path` variable does not have a trailing slash](https://github.com/boblemaire/IoTaWatt/blob/d8eba9239988acc4c459ff88abe5550d8c69f740/SD/graph2.js#L1367)

See PR: #272