### PR TITLE
Console error when deselecting graph2 saved graph

### DIFF
--- a/SD/graph2.js
+++ b/SD/graph2.js
@@ -1362,6 +1362,9 @@ $("#graph-select").change(function () {
   for (index = 0; index < savedgraphs.length; index++) {
     if (name == savedgraphs[index].name) break;
   }
+  if (index >= savedgraphs.length) {
+    return;
+  }
 
   $.ajax({
     url: path + "/graphs/" + savedgraphs[index].id,


### PR DESCRIPTION
This occurs when you select a saved graph, then deselect that saved graph by selecting "Select graph:" - A console error is raised: _(Ignore the line numbers, this has changed since I captured the error)_
> Uncaught TypeError: Cannot read property 'id' of undefined
> at HTMLSelectElement. (graph2.js:1199)
> at HTMLSelectElement.dispatch (jquery.min.js:2)
> at HTMLSelectElement.v.handle (jquery.min.js:2)

See PR: #272