### PR TITLE
Set viewport meta tag in index.htm

### DIFF
--- a/SD/index.htm
+++ b/SD/index.htm
@@ -3,6 +3,7 @@
 <html lang="en-US">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
 <title>IoTaWatt Configuration app</title>
 <link rel="stylesheet" type="text/css" href="cnfstyle.css">
 


### PR DESCRIPTION
This fixes the default zoom level in mobile phones. Reference: https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag#Viewport_width_and_screen_width

> Suppress the small zoom applied by many smartphones by setting the initial scale and minimum-scale values to 0.86. The result is horizontal scroll is suppressed in any orientation and the user can zoom in if they want to.

Tested on a Pixel 4 XL.

Before:
![Screenshot_20201125-131838](https://user-images.githubusercontent.com/5298134/100268019-63853580-2f22-11eb-9e97-874b92d86e01.png)

After:
![Screenshot_20201125-132059](https://user-images.githubusercontent.com/5298134/100268036-6bdd7080-2f22-11eb-9ef9-17bca1977853.png)
