### PR TITLE
Add support for Prometheus Open Metrics format

### DIFF
--- a/Firmware/IotaWatt/webServer.h
+++ b/Firmware/IotaWatt/webServer.h
@@ -40,5 +40,6 @@ void handlePasswords();
 void handleQuery();
 void handleUpdate();
 void handleDSTtest();
+void handleMetrics();
 
 #endif


### PR DESCRIPTION
This adds support for a `/metrics` http endpoint that exposes basic metrics in [Open Metrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md) format. 

I hope I got all the units right and if there's anything else I should expose, I'd happily add it. 